### PR TITLE
Fix to have it work with npm 0.3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "xml2js",
   "description": "Simple XML to JavaScript object converter.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": "maqr <maqr.lollerskates@gmail.com>",
   "keywords": ["xml", "json"],
   "directories": { "lib": "./lib" },
+  "main": "lib/index.js",
   "dependencies" : { "sax" : ">=0.1.1" }
 }


### PR DESCRIPTION
xml2js broke with a recent npm release. This patch fixes it.
