### PR TITLE
Add "main" entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "xml2js",
   "description": "Simple XML to JavaScript object converter.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": "maqr <maqr.lollerskates@gmail.com>",
   "keywords": ["xml", "json"],
   "directories": { "lib": "./lib" },
+  "main": "./lib/index",
   "dependencies" : { "sax" : ">=0.1.1" }
 }


### PR DESCRIPTION
Recent versions of NPM have stopped automatically looking in "./lib" to find index.js. This patch adds a "main" entry to `package.json` to explicitly declare where the root module is.
