### PR TITLE
added simple error handler to the sax parser

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -28,6 +28,11 @@
       this.EXPLICIT_CHARKEY = options.explicitCharkey;
       this.resultObject = null;
       stack = [];
+
+      this.saxParser.onerror = _bind(function(err) {
+       throw err;
+      }, this);
+
       this.saxParser.onopentag = __bind(function(node) {
         var key, obj, _ref;
         obj = {};


### PR DESCRIPTION
Hi, I added simple error handler to the sax parser, so that XML parse errors are not silently swallowed, as otherwise xml2js was failing silently without my being able to tell what was causing the errors.
