### PR TITLE
Emits an error even for the sax event onerror

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -13,7 +13,7 @@
   exports.Parser = (function() {
     __extends(Parser, events.EventEmitter);
     function Parser(opts) {
-      this.parseString = __bind(this.parseString, this);      var key, options, stack, value;
+      this.parseString = __bind(this.parseString, this);      var err, key, options, stack, value;
       options = {
         explicitCharkey: false,
         trim: true,
@@ -28,6 +28,13 @@
         trim: false,
         normalize: false
       });
+      err = false;
+      this.saxParser.onerror = __bind(function(error) {
+        if (!err) {
+          err = true;
+          return this.emit("error", error);
+        }
+      }, this);
       this.EXPLICIT_CHARKEY = options.explicitCharkey;
       this.resultObject = null;
       stack = [];

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -20,6 +20,15 @@ class exports.Parser extends events.EventEmitter
       trim: false,
       normalize: false
     }
+    
+    # emit one error event if the sax parser fails. this is mostly a hack, but
+    # the sax parser isn't state of the art either.
+    err = false
+    @saxParser.onerror = (error) =>
+      if ! err
+        err = true
+        @emit "error", error
+    
     # always use the '#' key, even if there are no subkeys
     # setting this property by and is deprecated, yet still supported.
     # better pass it as explicitCharkey option to the constructor


### PR DESCRIPTION
The solution is kinda hackish, but the sax parser isn't state of the art either. If there's a parsing error, the end event for xml2js isn't emitted. If sax emits onerror, then it is going to emit that event for every char, that's why I implemented the flag to emit the error only once. Listening with parser.once('error', callback) kills node with uncaught exceptions which in turn requires a lot of spaghetti to keep the application running. I guess this workaround works best for kind of error reporting.

About the 'state of the art' statement I made above, here is some test input to prove it:
- `'<a><b>foo</b><c>bar</c></a>'` - is parsed as { b: 'foo', c: 'bar' }
- `'This is not XML!'` - does nothing on your implementation, on my implementation it emits an error event.
- `'<a><b>foo</b><c>bar</c></a>This is not XML!'` - this is the part where the sax parser fails. The string is parsed as { b: 'foo', c: 'bar' }, but no error events are emitted.

I tried to implement a cleaner solution, but sax does not emit its onend event (issue: https://github.com/isaacs/sax-js/issues/14).

Example script:

<pre>
var xml2js = require('xml2js');
var parser = new xml2js.Parser();
var xml = 'This is not XML!';

parser.on('error', function (error) {
    console.error(error);
});

parser.on('end', function (result) {
    console.log(result);
});

parser.parseString(xml);
</pre>
