### PR TITLE
Specify attribute object key option

### DIFF
--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -13,7 +13,9 @@ class exports.Parser extends events.EventEmitter
     options =
       explicitCharkey: false
       trim: true
-      # normalize implicates trimming, just so you know
+      # attribute object key, so you can choose whatever you want
+      attrkey: "@"
+     # normalize implicates trimming, just so you know
       normalize: true
     # overwrite them with the specified options, if any
     options[key] = value for own key, value of opts
@@ -44,9 +46,9 @@ class exports.Parser extends events.EventEmitter
       obj = {}
       obj["#"] = ""
       for own key of node.attributes
-        if "@" not of obj
-          obj["@"] = {}
-        obj["@"][key] = node.attributes[key]
+        if options.attrkey not of obj
+          obj[options.attrkey] = {}
+        obj[options.attrkey][key] = node.attributes[key]
 
       # need a place to store the node name
       obj["#name"] = node.name


### PR DESCRIPTION
Added an option to allow you to change the attribute object key  

Currently `"@"` is used and doesn't allow for dotted use ex `foo.@.bar` added option to change it

Still need to compile new js version (please check my coffee script but i think i got it right... still need to compile into .js file)
