### PR TITLE
Emits 'end' event if trimmed string argument is empty string

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -128,6 +128,10 @@
           return cb(err);
         });
       }
+      if (str.toString().trim() === '') {
+        this.emit("end", null);
+        return true;
+      }
       return this.saxParser.write(str.toString());
     };
     return Parser;

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -119,4 +119,8 @@ class exports.Parser extends events.EventEmitter
       @on "error", (err) ->
         cb err
         
+    if str.toString().trim() is ''
+      @emit "end", null
+      return true
+      
     @saxParser.write str.toString()

--- a/test/xml2js.test.coffee
+++ b/test/xml2js.test.coffee
@@ -67,7 +67,7 @@ module.exports =
   'test disable normalize and trim': skeleton(normalize: false, trim: false, (r) ->
     assert.equal r['whitespacetest']['#'], '\n        Line One\n        Line Two\n    ')
 
-  'test default root node eliminiation': skeleton(__xmlString: '<root></root>', (r) ->
+  'test default root node elimination': skeleton(__xmlString: '<root></root>', (r) ->
     assert.deepEqual r, {})
 
   'test disabled root node elimination': skeleton(__xmlString: '<root></root>', explicitRoot: true, (r) ->
@@ -78,6 +78,9 @@ module.exports =
 
   'test empty tag result specified null': skeleton(emptyTag: null, (r) ->
     assert.equal r['emptytest'], null)
+
+  'test empty string result specified null': skeleton(__xmlString: ' ', (r) ->
+    assert.equal r, null)
 
   'test parse with custom char and attribute object keys': skeleton(attrkey: 'attrobj', charkey: 'charobj', (r) ->
     assert.equal r['chartest']['attrobj']['desc'], 'Test for CHARs'


### PR DESCRIPTION
I added a workaround to trigger 'end' when the string given as argument to parseString is empty (more precisely, when the trimmed string is empty, like '       '). It doesn't call sax.
