### PR TITLE
Added option to ignore all attributes entirely

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -24,7 +24,8 @@
         normalize: true,
         attrkey: "@",
         charkey: "#",
-        explicitArray: false
+        explicitArray: false,
+        ignoreAttrs: false
       };
       for (key in opts) {
         if (!__hasProp.call(opts, key)) continue;
@@ -51,13 +52,15 @@
         var key, obj, _ref;
         obj = {};
         obj[charkey] = "";
-        _ref = node.attributes;
-        for (key in _ref) {
-          if (!__hasProp.call(_ref, key)) continue;
-          if (!(attrkey in obj)) {
-            obj[attrkey] = {};
+        if (!options.ignoreAttrs) {
+          _ref = node.attributes;
+          for (key in _ref) {
+            if (!__hasProp.call(_ref, key)) continue;
+            if (!(attrkey in obj)) {
+              obj[attrkey] = {};
+            }
+            obj[attrkey][key] = node.attributes[key];
           }
-          obj[attrkey][key] = node.attributes[key];
         }
         obj["#name"] = node.name;
         return stack.push(obj);

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -21,6 +21,8 @@ class exports.Parser extends events.EventEmitter
       charkey: "#"
       # always put child nodes in an array
       explicitArray: false
+      # ignore all attributes regardless
+      ignoreAttrs: false
     # overwrite them with the specified options, if any
     options[key] = value for own key, value of opts
 
@@ -52,10 +54,11 @@ class exports.Parser extends events.EventEmitter
     @saxParser.onopentag = (node) =>
       obj = {}
       obj[charkey] = ""
-      for own key of node.attributes
-        if attrkey not of obj
-          obj[attrkey] = {}
-        obj[attrkey][key] = node.attributes[key]
+      unless options.ignoreAttrs
+        for own key of node.attributes
+          if attrkey not of obj
+            obj[attrkey] = {}
+          obj[attrkey][key] = node.attributes[key]
 
       # need a place to store the node name
       obj["#name"] = node.name

--- a/test/xml2js.test.coffee
+++ b/test/xml2js.test.coffee
@@ -101,6 +101,18 @@ module.exports =
     assert.equal r['arraytest'][0]['item'][1]['subitem'][0], 'Foo.'
     assert.equal r['arraytest'][0]['item'][1]['subitem'][1], 'Bar.')
 
+  'test ignore attributes': skeleton(ignoreAttrs: true, (r) ->
+    assert.equal r['chartest'], 'Character data here!'
+    assert.equal r['cdatatest'], 'CDATA here!'
+    assert.deepEqual r['nochartest'], {}
+    assert.equal r['listtest']['item'][0]['#'], 'This is character data!'
+    assert.equal r['listtest']['item'][0]['subitem'][0], 'Foo(1)'
+    assert.equal r['listtest']['item'][0]['subitem'][1], 'Foo(2)'
+    assert.equal r['listtest']['item'][0]['subitem'][2], 'Foo(3)'
+    assert.equal r['listtest']['item'][0]['subitem'][3], 'Foo(4)'
+    assert.equal r['listtest']['item'][1], 'Qux.'
+    assert.equal r['listtest']['item'][2], 'Quux.')
+
   'test simple callback mode': (test) ->
     x2js = new xml2js.Parser()
     fs.readFile fileName, (err, data) ->


### PR DESCRIPTION
This results in a much "cleaner" object graph if you're not interested
in attributes - for example, if they just contain type information, as is the case with many serialized XML graphs
