### PR TITLE
 'sys' has been deprecated

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,6 @@
+if (process.versions.node.match(/^0.3/)) {
+  module.exports = require("util");
+} else {
+  // This module is called "sys" in 0.2.x
+  module.exports = require("sys");
+}

--- a/test/xml2js.test.coffee
+++ b/test/xml2js.test.coffee
@@ -1,7 +1,7 @@
 # use zap to run tests, it also detects CoffeeScript files
 xml2js = require '../lib/xml2js'
 fs = require 'fs'
-sys = require 'sys'
+util = require '../lib/util'
 assert = require 'assert'
 path = require 'path'
 
@@ -23,7 +23,7 @@ skeleton = (options, checks) ->
 
 module.exports =
   'test parse with defaults': skeleton(undefined, (r) ->
-    console.log 'Result object: ' + sys.inspect(r, false, 10)
+    console.log 'Result object: ' + util.inspect(r, false, 10)
     assert.equal r['chartest']['@']['desc'], 'Test for CHARs'
     assert.equal r['chartest']['#'], 'Character data here!'
     assert.equal r['cdatatest']['@']['desc'], 'Test for CDATA'


### PR DESCRIPTION
The `sys` module has been deprecated. 

However for the sake of backwards compatibility I added the `lib/util.js` module. 

Thanks to `node_redis` for the [idea](https://github.com/mranney/node_redis/blob/master/lib/util.js)
