### PR TITLE
Added option to normalize tag names (default disabled)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ value})``. Possible options are:
   * `explicitCharkey` (default: `false`)
   * `trim` (default: `false`): Trim the whitespace at the beginning and end of
     text nodes.
+  * `normalizeTags` (default: `false`): Normalize all tag names to lowercase.
   * `normalize` (default: `false`): Trim whitespaces inside text nodes.
   * `explicitRoot` (default: `true`): Set this if you want to get the root
     node in the resulting object.

--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -18,6 +18,7 @@
       explicitCharkey: false,
       trim: true,
       normalize: true,
+      normalizeTags: false,
       attrkey: "@",
       charkey: "#",
       explicitArray: false,
@@ -30,6 +31,7 @@
       explicitCharkey: false,
       trim: false,
       normalize: false,
+      normalizeTags: false,
       attrkey: "$",
       charkey: "_",
       explicitArray: true,
@@ -115,7 +117,7 @@
             }
           }
         }
-        obj["#name"] = node.name;
+        obj["#name"] = _this.options.normalizeTags ? node.name.toLowerCase() : node.name;
         return stack.push(obj);
       };
       this.saxParser.onclosetag = function() {

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -30,6 +30,7 @@ exports.defaults =
     explicitCharkey: false
     trim: false
     normalize: false
+    normalizeTags: false
     attrkey: "$"
     charkey: "_"
     explicitArray: true
@@ -94,7 +95,7 @@ class exports.Parser extends events.EventEmitter
             obj[attrkey][key] = node.attributes[key]
 
       # need a place to store the node name
-      obj["#name"] = node.name
+      obj["#name"] = if @options.normalizeTags then node.name.toLowerCase() else node.name
       stack.push obj
 
     @saxParser.onclosetag = =>
@@ -102,9 +103,6 @@ class exports.Parser extends events.EventEmitter
       nodeName = obj["#name"]
       delete obj["#name"]
       
-      if @options.normalizeTags
-       nodeName = nodeName.toLowerCase()
-
       s = stack[stack.length - 1]
       # remove the '#' key altogether if it's blank
       if obj[charkey].match(/^\s*$/)

--- a/test/fixtures/sample.xml
+++ b/test/fixtures/sample.xml
@@ -23,6 +23,11 @@
         <item><subitem>Foo.</subitem><subitem>Bar.</subitem></item>
     </arraytest>
     <emptytest/>
+    <tagcasetest>
+        <tAg>something</tAg>
+        <TAG>something else</TAG>
+        <tag>something third</tag>
+    </tagcasetest>
     <ordertest>
         <one>1</one>
         <two>2</two>

--- a/test/xml2js.test.coffee
+++ b/test/xml2js.test.coffee
@@ -59,7 +59,8 @@ module.exports =
     equ r.sample.listtest[0].item[0].subitem[2], 'Foo(3)'
     equ r.sample.listtest[0].item[0].subitem[3], 'Foo(4)'
     equ r.sample.listtest[0].item[1], 'Qux.'
-    equ r.sample.listtest[0].item[2], 'Quux.')
+    equ r.sample.listtest[0].item[2], 'Quux.'
+    equ r.sample.tagcasetest.length, 3)
 
   'test parse with explicitCharkey': skeleton(explicitCharkey: true, (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10
@@ -121,6 +122,10 @@ module.exports =
 
   'test invalid empty XML file': skeleton(__xmlString: ' ', (r) ->
     equ r, null)
+
+  'test enabled normalizeTags': skeleton(normalizeTags: true, (r) ->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    equ r.sample.tagcasetest.length, 1)
 
   'test parse with custom char and attribute object keys': skeleton(attrkey: 'attrobj', charkey: 'charobj', (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10


### PR DESCRIPTION
When XML is coming from many sources some capitalization may be different in the tag names and because javascript is case sensitive `<tag>`  and `<Tag>` and `<TAG>` are 3 separate objects

This adds an optional parameter to normalize tag names so that they can be easily accessed without testing for all the different case combinations  
