### PR TITLE
Exception in callback

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -164,7 +164,11 @@
             }
             return _results;
           })()).concat(nodeName).join("/");
-          obj = _this.options.validator(xpath, s && s[nodeName], obj);
+          try {
+            obj = _this.options.validator(xpath, s && s[nodeName], obj);
+          } catch (e) {
+            _this.emit("error", e);
+          }
         }
         if (stack.length > 0) {
           if (!_this.options.explicitArray) {
@@ -221,15 +225,7 @@
         this.emit("end", null);
         return true;
       }
-      try {
-        return this.saxParser.write(str.toString());
-      } catch (ex) {
-        if ((cb != null) && typeof cb === "function") {
-          return cb(ex.message);
-        } else {
-          return this.emit("error", ex.message);
-        }
-      }
+      this.saxParser.write(str.toString());
     };
 
     return Parser;

--- a/test/xml2js.test.coffee
+++ b/test/xml2js.test.coffee
@@ -219,7 +219,7 @@ module.exports =
   'test validation error': (test) ->
     x2js = new xml2js.Parser({validator: validator})
     x2js.parseString '<validationerror/>', (err, r) ->
-      equ err, 'Validation error!'
+      equ err.message, 'Validation error!'
       test.finish()
 
   'test error throwing': (test) ->


### PR DESCRIPTION
The issue #69 & #70 have discussed the exception that threw by callback. But the #70 don't resolve it correctly. The following test case can't passed under 0.2.4. Actually, the callback has been called twice. 

```
  'test error throwing': (test) ->
    xml = '<?xml version="1.0" encoding="utf-8"?><test>test</test>'
    i = 0;
    try
      xml2js.parseString xml, (err, parsed) ->
        i = i + 1
        # throw something custom
        throw new Error 'Custom error message'
    catch e
      equ i, 1
      equ e.message, 'Custom error message'
      test.finish()
```

The test result of this case:

```
xml2js/test error throwing... failed

assert.js:102
  throw new assert.AssertionError({
        ^
AssertionError: 2 == 1
    at Object.module.exports.test error throwing (/Users/jacksontian/git/node-xml2js/test/xml2js.test.coffee:309:9)
    at Object.<anonymous> (/Users/jacksontian/git/node-xml2js/node_modules/zap/bin/zap:49:25)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:492:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
```

The reason is that exception callback threw will be caught by try/catch. In catch block, will emit `error` event, then will reset all listeners and execute callback again. 

Because all listeners have removed, the callback throws exception again. The catch block emit `error` event again. Any event emitter instance(no `error` event listener) will throw `Uncaught, unspecified 'error' event.` exception when emit the `error` event.

The issue #69 reproduced. About emitter, here is API: http://nodejs.org/docs/latest/api/events.html#events_class_events_eventemitter

My solution is execute callback async with process.nextTick. The `parseString` use async style API, execute callback asyncly is make sense. Actually, the `saxParser.write()` don't throw exception, the sax parser pass exception via `onerror`, so the try/catch block can be removed also. And the validator maybe throw exception, so try/catch the exception and pass it via `error` event.

Don't let users to try/catch parseString, it's stupid.

This pull request fix #71. :)

Regards,
Jackson Tian
