### PR TITLE
Skip empty children properties in explicit children mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ value})``. Possible options are:
     (the first character is the same as attrkey) that contains its local name
     and namespace URI.
   * `explicitChildren` (default `false`): Put child elements to separate
-    property. Doesn't work with `mergeAttrs = true`. Meaningless for version
-    0.1.
+    property. Doesn't work with `mergeAttrs = true`. If element has no children
+    then "children" won't be created. Meaningless for version 0.1.
   * `childkey` (default `$$`): Prefix that is used to access child elements if
     `explicitChildren` is set to `true`. Meaningless for version 0.1.
   * `charsAsChildren` (default `false`): Determines whether chars should be

--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -186,7 +186,9 @@
             node[_this.options.charkey] = obj[_this.options.charkey];
             delete obj[_this.options.charkey];
           }
-          node[_this.options.childkey] = obj;
+          if (Object.getOwnPropertyNames(obj).length > 0) {
+            node[_this.options.childkey] = obj;
+          }
           obj = node;
         }
         if (stack.length > 0) {

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -153,7 +153,9 @@ class exports.Parser extends events.EventEmitter
           node[@options.charkey] = obj[@options.charkey]
           delete obj[@options.charkey]
 
-        node[@options.childkey] = obj
+        if Object.getOwnPropertyNames(obj).length > 0
+          node[@options.childkey] = obj
+
         obj = node
 
       # check whether we closed all the open tags

--- a/test/fixtures/sample.xml
+++ b/test/fixtures/sample.xml
@@ -2,6 +2,7 @@
     <chartest desc="Test for CHARs">Character data here!</chartest>
     <cdatatest desc="Test for CDATA" misc="true"><![CDATA[CDATA here!]]></cdatatest>
     <nochartest desc="No data" misc="false" />
+    <nochildrentest desc="No data" misc="false" />
     <whitespacetest desc="Test for normalizing and trimming">
         Line One
         Line Two

--- a/test/xml2js.test.coffee
+++ b/test/xml2js.test.coffee
@@ -112,25 +112,19 @@ module.exports =
     equ r.sample.$$.listtest[0].$$.item[0].$$.subitem[3], 'Foo(4)'
     equ r.sample.$$.listtest[0].$$.item[1], 'Qux.'
     equ r.sample.$$.listtest[0].$$.item[2], 'Quux.'
+    equ r.sample.$$.nochildrentest[0].$$, undefined
     # determine number of items in object
     equ Object.keys(r.sample.$$.tagcasetest[0].$$).length, 3)
 
+  'test element without children': skeleton(explicitChildren: true, (r) ->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    equ r.sample.$$.nochildrentest[0].$$, undefined)
+
   'test parse with explicitChildren and charsAsChildren': skeleton(explicitChildren: true, charsAsChildren: true, (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10
-    equ r.sample.$$.chartest[0].$.desc, 'Test for CHARs'
     equ r.sample.$$.chartest[0].$$._, 'Character data here!'
-    equ r.sample.$$.cdatatest[0].$.desc, 'Test for CDATA'
-    equ r.sample.$$.cdatatest[0].$.misc, 'true'
     equ r.sample.$$.cdatatest[0].$$._, 'CDATA here!'
-    equ r.sample.$$.nochartest[0].$.desc, 'No data'
-    equ r.sample.$$.nochartest[0].$.misc, 'false'
     equ r.sample.$$.listtest[0].$$.item[0].$$._, '\n            This  is\n            \n            character\n            \n            data!\n            \n        '
-    equ r.sample.$$.listtest[0].$$.item[0].$$.subitem[0], 'Foo(1)'
-    equ r.sample.$$.listtest[0].$$.item[0].$$.subitem[1], 'Foo(2)'
-    equ r.sample.$$.listtest[0].$$.item[0].$$.subitem[2], 'Foo(3)'
-    equ r.sample.$$.listtest[0].$$.item[0].$$.subitem[3], 'Foo(4)'
-    equ r.sample.$$.listtest[0].$$.item[1], 'Qux.'
-    equ r.sample.$$.listtest[0].$$.item[2], 'Quux.'
     # determine number of items in object
     equ Object.keys(r.sample.$$.tagcasetest[0].$$).length, 3)
 


### PR DESCRIPTION
I belive that we shouldn't add `childattr` property for nodes that have no children.

Tests added/updated.
Docs updated.

Also cleans `charsAsChildren=true` test case to make it more meaningfull.
