### PR TITLE
Fix tests to properly handle windows \r\n line endings

### DIFF
--- a/test/xml2js.test.coffee
+++ b/test/xml2js.test.coffee
@@ -4,6 +4,7 @@ fs = require 'fs'
 util = require 'util'
 assert = require 'assert'
 path = require 'path'
+os = require 'os'
 
 fileName = path.join __dirname, '/fixtures/sample.xml'
 
@@ -16,7 +17,8 @@ skeleton = (options, checks) ->
       checks r
       test.finish()
     if not xmlString
-      fs.readFile fileName, (err, data) ->
+      fs.readFile fileName, 'utf8', (err, data) ->
+        data = data.split(os.EOL).join('\n')
         x2js.parseString data
     else
       x2js.parseString xmlString


### PR DESCRIPTION
When trying to run the test suite on a Windows box, I found that several of them failed. It turned out the issue was that on windows, the sample xml file is loaded with `\r\n` line endings. The assertions are explicitly checking for `\n` line endings and failing.

This change normalizes the line endings to `\n` before passing to the actual test function, thus fixing the issue. I've tried this on both Windows and on a Mac; tests now pass in both environments.
