### PR TITLE
Fixes xml strings that aren't closed

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -359,7 +359,7 @@
         this.emit("end", null);
         return true;
       }
-      return this.saxParser.write(bom.stripBOM(str.toString()));
+      return this.saxParser.write(bom.stripBOM(str.toString())).close();
     };
 
     return Parser;

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -299,7 +299,7 @@ class exports.Parser extends events.EventEmitter
       @emit "end", null
       return true
 
-    @saxParser.write bom.stripBOM str.toString()
+    @saxParser.write(bom.stripBOM str.toString()).close()
 
 exports.parseString = (str, a, b) ->
   # let's determine what we got as arguments

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -285,8 +285,10 @@ module.exports =
         throw new Error 'error throwing in callback'
       throw new Error 'error throwing outside'
     catch e
-      # don't catch the exception that was thrown by callback
-      equ e.message, 'error throwing outside'
+      # the stream is finished by the time the parseString method is called
+      # so the callback, which is synchronous, will bubble the inner error
+      # out to here, make sure that happens
+      equ e.message, 'error throwing in callback'
       test.finish()
 
   'test xmlns': skeleton(xmlns: true, (r) ->
@@ -340,3 +342,9 @@ module.exports =
         equ err, null
         assert.deepEqual resWithNew, resWithoutNew
         test.done()
+
+  'test not closed but well formed xml': (test) ->
+    xml = "<test>"
+    xml2js.parseString xml, (err, parsed) ->
+      assert.equal err.message, 'Unclosed root tag\nLine: 0\nColumn: 6\nChar: '
+      test.finish()


### PR DESCRIPTION
The parser never returns if given strings like "<test><foo>" when calling parseString() because the sax close() method was never called.

This fixes that by calling close on the sax write stream.

Note that the unit test that covers throwing an error synchronously was in my opinion actually wrong, since an error generated synchronously does and should bubble up immediately - so I flipped the logic of the unit test and added an appropriate comment.
