### PR TITLE
ignore the expection which is threw by saxParser.write

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -383,7 +383,10 @@
         this.emit("end", null);
         return true;
       }
-      return this.saxParser.write(bom.stripBOM(str.toString())).close();
+      try {
+        return this.saxParser.write(bom.stripBOM(str.toString())).close();
+      } catch (e) {
+      }
     };
 
     return Parser;


### PR DESCRIPTION
The expection is threw from https://github.com/isaacs/sax-js/blob/master/lib/sax.js#L913, but it had be handled at https://github.com/isaacs/sax-js/blob/master/lib/sax.js#L644 before, so I ignore the first one which throw the error ungracefully.

However, maybe this is a bug of sax, not the xml2js, we should not just ignore it. Wish you a better idea.
