### PR TITLE
Catch thrown sax errors; only invoke parseString callback once

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -220,7 +220,7 @@
     };
 
     Parser.prototype.reset = function() {
-      var attrkey, charkey, err, ontext, stack,
+      var attrkey, charkey, ontext, stack,
         _this = this;
       this.removeAllListeners();
       this.saxParser = sax.parser(this.options.strict, {
@@ -228,10 +228,11 @@
         normalize: false,
         xmlns: this.options.xmlns
       });
-      err = false;
+      this.saxParser.errThrown = false;
       this.saxParser.onerror = function(error) {
-        if (!err) {
-          err = true;
+        _this.saxParser.resume();
+        if (!_this.saxParser.errThrown) {
+          _this.saxParser.errThrown = true;
           return _this.emit("error", error);
         }
       };
@@ -270,7 +271,7 @@
         return stack.push(obj);
       };
       this.saxParser.onclosetag = function() {
-        var cdata, emptyStr, node, nodeName, obj, old, s, xpath;
+        var cdata, emptyStr, err, node, nodeName, obj, old, s, xpath;
         obj = stack.pop();
         nodeName = obj["#name"];
         delete obj["#name"];
@@ -357,6 +358,7 @@
     };
 
     Parser.prototype.parseString = function(str, cb) {
+      var err;
       if ((cb != null) && typeof cb === "function") {
         this.on("end", function(result) {
           this.reset();
@@ -383,7 +385,15 @@
         this.emit("end", null);
         return true;
       }
-      return this.saxParser.write(bom.stripBOM(str.toString())).close();
+      try {
+        return this.saxParser.write(bom.stripBOM(str.toString())).close();
+      } catch (_error) {
+        err = _error;
+        if (!this.saxParser.errThrown) {
+          this.emit('error', err);
+          return this.saxParser.errThrown = true;
+        }
+      }
     };
 
     return Parser;

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -248,6 +248,13 @@ module.exports =
           equ r.sample.chartest[0]._, 'Character data here!'
           test.finish()
 
+  'test element with garbage XML': (test) ->
+    x2js = new xml2js.Parser()
+    xmlString = "<<>fdfsdfsdf<><<><??><<><>!<>!<!<>!."
+    x2js.parseString xmlString, (err, result) ->
+      assert.notEqual err, null
+      test.finish()
+
   'test simple function without options': (test) ->
     fs.readFile fileName, (err, data) ->
       xml2js.parseString data, (err, r) ->


### PR DESCRIPTION
This is a fix for issue #118.  When parsing badly formed XML, Sax throws its own custom error event but will later throw a Javascript error when parsing resumes.  This Javascript error was escaping xml2js and being thrown into the calling app instead of being provided as the first argument to the result callback.

This change catches those Javascript errors emitted by Sax.  Additionally, it ensures that the xml2js result callback is only called once since Sax is throwing multiple errors.
