### PR TITLE
Don't emit 'error' for excptns caught in 'end' cbs

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -343,6 +343,7 @@
               obj[nodeName] = old;
             }
             _this.resultObject = obj;
+            _this.saxParser.ended = true;
             return _this.emit("end", _this.resultObject);
           }
         };
@@ -401,7 +402,7 @@
         return this.saxParser.write(bom.stripBOM(str.toString())).close();
       } catch (_error) {
         err = _error;
-        if (!this.saxParser.errThrown) {
+        if (!(this.saxParser.errThrown || this.saxParser.ended)) {
           this.emit('error', err);
           return this.saxParser.errThrown = true;
         }

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -285,6 +285,7 @@ class exports.Parser extends events.EventEmitter
           obj[nodeName] = old
 
         @resultObject = obj
+        @saxParser.ended = true
         @emit "end", @resultObject
 
     ontext = (text) =>
@@ -323,7 +324,7 @@ class exports.Parser extends events.EventEmitter
     try
       @saxParser.write(bom.stripBOM str.toString()).close()
     catch err
-      unless @saxParser.errThrown
+      unless @saxParser.errThrown or @saxParser.ended
         @emit 'error', err
         @saxParser.errThrown = true
 

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -327,6 +327,23 @@ module.exports =
       equ e.message, 'Custom error message'
       test.finish()
 
+  'test no error event after end': (test) ->
+    xml = '<?xml version="1.0" encoding="utf-8"?><test>test</test>'
+    i = 0
+    x2js = new xml2js.Parser()
+    x2js.on 'error', ->
+      i = i + 1
+
+    x2js.on 'end', ->
+      #This is a userland callback doing something with the result xml.
+      #Errors in here should not be passed to the parser's 'error' callbacks
+      throw new Error('some error in happy path')
+
+    x2js.parseString(xml)
+
+    equ i, 0
+    test.finish()
+
   'test empty CDATA': (test) ->
     xml = '<xml><Label><![CDATA[]]></Label><MsgId>5850440872586764820</MsgId></xml>'
     xml2js.parseString xml, (err, parsed) ->


### PR DESCRIPTION
Currently if the parser 'end' event is used to receive the parsed object and continue execution, there appears to be a bug with the interaction between the 'end' event callback and the parsers 'error' event. If the callback throws for whatever reason, the error event is emitted from the parser (even though parsing has finished). This appears to happen because the try/catch block surrounding @saxParser.write also ends up encompassing all the 'end' event callbacks due to the sync nature of EventEmitter.

The simplest fix seemed to be adding an 'ended' flag which checks if parsing has ended before emitting the error event.
