### PR TITLE
Pass all stack information to validator

### DIFF
--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -254,7 +254,7 @@ class exports.Parser extends events.EventEmitter
       if @options.validator?
         xpath = "/" + (node["#name"] for node in stack).concat(nodeName).join("/")
         try
-          obj = @options.validator(xpath, s and s[nodeName], obj)
+          obj = @options.validator(xpath, s and s[nodeName], obj, stack)
         catch err
           @emit "error", err
 

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -36,7 +36,7 @@ is an existing value at this path it is supplied in `currentValue` (e.g. this is
 later item in an array).
 If the validation fails it should throw a `ValidationError`.
 ###
-validator = (xpath, currentValue, newValue) ->
+validator = (xpath, currentValue, newValue, stack) ->
   if xpath == '/sample/validatortest/numbertest'
     return Number(newValue)
   else if xpath in ['/sample/arraytest', '/sample/validatortest/emptyarray', '/sample/validatortest/oneitemarray']


### PR DESCRIPTION
This allows access to more information than is available in xpath, like namespace information for ancestor nodes. This allows implementing #141 as a validator.
