### PR TITLE
Inherit parent namespace

### DIFF
--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -225,7 +225,7 @@ class exports.Parser extends events.EventEmitter
         for i in [stack.length - 1..0]
           break if uri
           uri = stack[i][@options.xmlnskey].uri
-        obj[@options.xmlnskey] = {uri: uri, local: node.local}
+        obj[@options.xmlnskey] = {uri: uri, local: node.local, ns: node.ns}
       stack.push obj
 
     @saxParser.onclosetag = =>


### PR DESCRIPTION
Otherwise child nodes do not have namespace if it is not explicitly defined. Failing example is [ipo.xml](http://www.w3.org/TR/xmlschema-0/#ipo.xml) where for example `shipTo` element does not have namespace set, when it should be `http://www.example.com/IPO`.
