### PR TITLE
Adding cdata while parsing

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -335,6 +335,8 @@
             }
             obj = node;
           }
+    		  if(cdata && obj !== 'object')
+    			  obj = {dat:obj};
           if (stack.length > 0) {
             return _this.assignOrPush(s, nodeName, obj);
           } else {


### PR DESCRIPTION
With this edit the parse of this 
`<node><![CDATA[test]]></node>` 
will return the object 
`{node:{dat:"test"}}`

This edit will be compatible with the builder once #134 will be merged