### PR TITLE
Fix for XML generation in IE

### DIFF
--- a/lib/bom.js
+++ b/lib/bom.js
@@ -13,3 +13,5 @@
   };
 
 }).call(this);
+
+//# sourceMappingURL=bom.map

--- a/lib/processors.js
+++ b/lib/processors.js
@@ -17,3 +17,5 @@
   };
 
 }).call(this);
+
+//# sourceMappingURL=processors.map

--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -127,7 +127,7 @@
         rootName = this.options.rootName;
       }
       render = function(element, obj) {
-        var attr, child, entry, index, key, value, _ref, _ref1;
+        var attr, child, entry, index, key, value;
         if (typeof obj !== 'object') {
           element.txt(obj);
         } else {
@@ -143,7 +143,7 @@
               }
             } else if (key === charkey) {
               element = element.txt(child);
-            } else if (typeof child === 'object' && ((child != null ? child.constructor : void 0) != null) && ((child != null ? (_ref = child.constructor) != null ? _ref.name : void 0 : void 0) != null) && (child != null ? (_ref1 = child.constructor) != null ? _ref1.name : void 0 : void 0) === 'Array') {
+            } else if (typeof child === 'object' && child instanceof Array) {
               for (index in child) {
                 if (!__hasProp.call(child, index)) continue;
                 entry = child[index];
@@ -434,3 +434,5 @@
   };
 
 }).call(this);
+
+//# sourceMappingURL=xml2js.map

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -118,7 +118,7 @@ class exports.Builder
             element = element.txt(child)
 
           # Case #3 Array data
-          else if typeof child is 'object' and child?.constructor? and child?.constructor?.name? and child?.constructor?.name is 'Array'
+          else if typeof child is 'object' and child instanceof Array
             for own index, entry of child
               if typeof entry is 'string'
                 element = element.ele(key, entry).up()


### PR DESCRIPTION
XML generation did not work correctly in IE when using Browserify-ed version of the code. It did not cope correctly with arrays.

This is a very minor change for an odd use case. But hopefully someone else will find it useful. Since it's IE specific, I'm not sure how to create a unit test for it.
