### PR TITLE
Make the options.async option parse the XML in chunks using setImmediate...

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -371,36 +371,49 @@
       })(this);
     };
 
+    Parser.prototype.processAsync = function() {
+      if (this.index > this.str.length) {
+        this.saxParser.close();
+        return;
+      }
+
+      var chunk = this.str.substr(this.index, this.options.chunkSize);
+      this.index += this.options.chunkSize;
+
+      this.saxParser = this.saxParser.write(chunk);
+
+      setImmediate(this.processAsync.bind(this));
+    };
+
     Parser.prototype.parseString = function(str, cb) {
       var err;
       if ((cb != null) && typeof cb === "function") {
         this.on("end", function(result) {
           this.reset();
-          if (this.options.async) {
-            return process.nextTick(function() {
-              return cb(null, result);
-            });
-          } else {
-            return cb(null, result);
-          }
+          return cb(null, result);
         });
         this.on("error", function(err) {
           this.reset();
-          if (this.options.async) {
-            return process.nextTick(function() {
-              return cb(err);
-            });
-          } else {
-            return cb(err);
-          }
+          return cb(err);
         });
       }
-      if (str.toString().trim() === '') {
+      str = str.toString();
+
+      if (str.trim() === '') {
         this.emit("end", null);
         return true;
       }
       try {
-        return this.saxParser.write(bom.stripBOM(str.toString())).close();
+        str = bom.stripBOM(str);
+        if (this.options.async) {
+          if (!("chunkSize" in this.options))
+            this.options.chunkSize = 10000;
+          this.index = 0;
+          this.str = str;
+          setImmediate(this.processAsync.bind(this));
+          return this.saxParser;
+        }
+        return this.saxParser.write(str).close();
       } catch (_error) {
         err = _error;
         if (!(this.saxParser.errThrown || this.saxParser.ended)) {


### PR DESCRIPTION
... to avoid blocking

I know this diff is against the generated xml2js.js file, but I'm not a coffee scripter, so I'm submitting what I'm able to.

Reason for this change:

My use case is to parse a very large XML file (~36MB).  Before this change, the parser would block during parsing, and parsing that 36MB file would block node for approx 60 sec.  With this change, options.async makes xml2js break the string up into chunks (by default 10000 bytes each, controllable with options.chunkSize), parse 1 chunk, and then call setImmediate to parse more.  This eliminates the blocking, even on large XML files.

I also changed the this.on("end" and this.on("error" to not check the async flag.  If the async flag is set, they will always be called asynchronously because of the setImmediate().

Sorry I couldn't do this on the original coffeescript, but I hope you will add this to the library.

Let me know if you have any questions/comments.
