### PR TITLE
added explicitArrayProcessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,16 @@ value})``. Possible options are:
     }
     ```
     Added in 0.4.1
+  * `explicitArrayProcessor` (defult: `null`):Allow setting explicitArray in function.
+    Acceptsa function with the following signature:
+    ```
+    javascript
+    function (parentName, newChild){
+      //decide if based on parentName and newChild, the child should be placed in an array
+      return true/false
+    }
+    ```
+    Added in 0.4.5
 
 Options for the `Builder` class
 -------------------------------

--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -72,6 +72,7 @@
       strict: true,
       attrNameProcessors: null,
       tagNameProcessors: null,
+      explicitArrayProcessor: null,
       rootName: 'root',
       xmldec: {
         'version': '1.0',
@@ -208,8 +209,10 @@
     }
 
     Parser.prototype.assignOrPush = function(obj, key, newValue) {
+      var array;
       if (!(key in obj)) {
-        if (!this.options.explicitArray) {
+        array = this.options.explicitArrayProcessor ? this.options.explicitArrayProcessor(key, newValue) : this.options.explicitArray;
+        if (!array) {
           return obj[key] = newValue;
         } else {
           return obj[key] = [newValue];
@@ -434,5 +437,3 @@
   };
 
 }).call(this);
-
-//# sourceMappingURL=xml2js.map

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description" : "Simple XML to JavaScript object converter.",
   "keywords" : ["xml", "json"],
   "homepage" : "https://github.com/Leonidas-from-XIV/node-xml2js",
-  "version" : "0.4.4",
+  "version" : "0.4.5",
   "author" : "Marek Kubica <marek@xivilization.net> (http://xivilization.net)",
   "contributors" : [
     "maqr <maqr.lollerskates@gmail.com> (https://github.com/maqr)",

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -67,6 +67,7 @@ exports.defaults =
     strict: true
     attrNameProcessors: null
     tagNameProcessors: null
+    explicitArrayProcessor: null
     # xml building options
     rootName: 'root'
     xmldec: {'version': '1.0', 'encoding': 'UTF-8', 'standalone': true}
@@ -161,7 +162,8 @@ class exports.Parser extends events.EventEmitter
 
   assignOrPush: (obj, key, newValue) =>
     if key not of obj
-      if not @options.explicitArray
+      array = if @options.explicitArrayProcessor then @options.explicitArrayProcessor(key, newValue) else @options.explicitArray
+      if not array
         obj[key] = newValue
       else
         obj[key] = [newValue]

--- a/test/fixtures/sample.xml
+++ b/test/fixtures/sample.xml
@@ -52,4 +52,12 @@
     </pfx:top>
     <attrNameProcessTest camelCaseAttr="camelCaseAttrValue" lowercaseattr="lowercaseattr" />
     <tagNameProcessTest/>
+    <explicitArrayProcessorTest>
+        <item>
+            <one/>
+        </item>
+        <items>
+            <one/>
+        </items>
+    </explicitArrayProcessorTest>
 </sample>

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -29,6 +29,9 @@ nameToUpperCase = (name) ->
 nameCutoff = (name) ->
   return name.substr(0, 4)
 
+pluralTagName = (key, newValue) ->
+  return key.slice(-1) == 's'
+
 ###
 The `validator` function validates the value at the XPath. It also transforms the value
 if necessary to conform to the schema or other validation information being used. If there
@@ -398,3 +401,8 @@ module.exports =
     console.log 'Result object: ' + util.inspect r, false, 10
     equ r.hasOwnProperty('SAMP'), true
     equ r.SAMP.hasOwnProperty('TAGN'), true)
+
+  'test explicitArrayProcessor': skeleton(explicitArrayProcessor: pluralTagName, (r) ->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    equ r.sample.explicitArrayProcessorTest.item.one, ''
+    equ r.sample.explicitArrayProcessorTest.items[0].one, '')


### PR DESCRIPTION
My specific case has to do with parsing iOS Xcode Storyboard XML, where tag names indicate whether the children will be single or multiple, e.g.

```
<scenes>
  <scene>
     <objects>
        <view>
          <subviews>
             <subview>
                ...
```

Using hard set explicitArray to 'true' requires accessing objects awkwardly:

```
storyboard.scenes[0].scene[0].objects[0].view[0]
```

Using hard set explicitArray to 'false' will make the code break in different scenarios, depending on whether the parent has a single child or multiple children:

```
storyboard.scenes[0].scene.objects // works when there's a single scene, breaks on multiple scenes
storyboard.scenes[0].scene[0].objects // ok when there are multiple scenes, breaks on single scenes
```

I added an option called explicitArrayProcessor that uses a function to determine whether a child element should be part in an array.
The function takes 2 parameters: the parent name and the child element

In my case I just check if the parent's name ends with an 's', and if so I assume child elements should be put in an array.

I think this can be useful in other scenarios as well.
