### PR TITLE
Add attrsAsValues to make attributes raw values

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,12 @@ value})``. Possible options are:
   * `mergeAttrs` (default: `false`): Merge attributes and child elements as
     properties of the parent, instead of keying attributes off a child
     attribute object. This option is ignored if `ignoreAttrs` is `false`.
+  * `attrsAsValues` (default: `false`): When used with `mergeAttrs`, makes
+    attributes as values, even with `explicitArray` set to `true`. This can
+    make it easier to distinguish between properties that were attributes,
+    and properties that were content (content will be an array, attributes
+    will be strings). If `explicitArray` is `false`, setting this option will
+    have no effect.
   * `validator` (default `null`): You can specify a callable that validates
     the resulting structure somehow, however you want. See unit tests
     for an example.

--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -87,7 +87,8 @@
       },
       headless: false,
       chunkSize: 10000,
-      emptyTag: ''
+      emptyTag: '',
+      attrsAsValues: false
     }
   };
 
@@ -226,9 +227,9 @@
       }
     };
 
-    Parser.prototype.assignOrPush = function(obj, key, newValue) {
+    Parser.prototype.assignOrPush = function(obj, key, isAttribute, newValue) {
       if (!(key in obj)) {
-        if (!this.options.explicitArray) {
+        if ((!this.options.explicitArray) || (isAttribute && this.options.attrsAsValues)) {
           return obj[key] = newValue;
         } else {
           return obj[key] = [newValue];
@@ -280,7 +281,7 @@
               newValue = node.attributes[key];
               processedKey = _this.options.attrNameProcessors ? processName(_this.options.attrNameProcessors, key) : key;
               if (_this.options.mergeAttrs) {
-                _this.assignOrPush(obj, processedKey, newValue);
+                _this.assignOrPush(obj, processedKey, true, newValue);
               } else {
                 obj[attrkey][processedKey] = newValue;
               }
@@ -355,7 +356,7 @@
             obj = node;
           }
           if (stack.length > 0) {
-            return _this.assignOrPush(s, nodeName, obj);
+            return _this.assignOrPush(s, nodeName, false, obj);
           } else {
             if (_this.options.explicitRoot) {
               old = obj;

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -107,6 +107,24 @@ module.exports =
     equ r.sample.listtest[0].single[0], 'Single'
     equ r.sample.listtest[0].attr[0], 'Attribute')
 
+  'test parse with mergeAttrs and attrsAsValues': skeleton(mergeAttrs: true, attrsAsValues: true, (r) ->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    equ r.sample.chartest[0].desc, 'Test for CHARs'
+    equ r.sample.chartest[0]._, 'Character data here!'
+    equ r.sample.cdatatest[0].desc, 'Test for CDATA'
+    equ r.sample.cdatatest[0].misc, 'true'
+    equ r.sample.cdatatest[0]._, 'CDATA here!'
+    equ r.sample.nochartest[0].desc, 'No data'
+    equ r.sample.nochartest[0].misc, 'false'
+    equ r.sample.listtest[0].item[0].subitem[0], 'Foo(1)'
+    equ r.sample.listtest[0].item[0].subitem[1], 'Foo(2)'
+    equ r.sample.listtest[0].item[0].subitem[2], 'Foo(3)'
+    equ r.sample.listtest[0].item[0].subitem[3], 'Foo(4)'
+    equ r.sample.listtest[0].item[1], 'Qux.'
+    equ r.sample.listtest[0].item[2], 'Quux.'
+    equ r.sample.listtest[0].single[0], 'Single'
+    equ r.sample.listtest[0].attr, 'Attribute')
+
   'test parse with mergeAttrs and not explicitArray': skeleton(mergeAttrs: true, explicitArray: false, (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10
     equ r.sample.chartest.desc, 'Test for CHARs'


### PR DESCRIPTION
This option works with mergeAttrs:true, and explicitArray:true,
essentially overriding explicitArray to false for attributes.

(I don't normally do coffeescript, so I hope the coffee isn't bad!) It's a fairly trivial change though.
