### PR TITLE
add new failing test demonstrating error with building xml from a date

### DIFF
--- a/test/builder.test.coffee
+++ b/test/builder.test.coffee
@@ -116,6 +116,15 @@ module.exports =
     diffeq expected, actual
     test.finish()
 
+  'test parsing a date': (test) ->
+    expected = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><adate>2000-01-01T00:00:00.0</adate>'
+    opts = renderOpts: pretty: false
+    builder = new xml2js.Builder opts
+    obj = {"adate": new Date(2000, 0, 1, 1, 0, 0, 0)}
+    actual = builder.buildObject obj
+    diffeq expected, actual
+    test.finish()
+    
   'test parser -> builder roundtrip': (test) ->
     fileName = path.join __dirname, '/fixtures/build_sample.xml'
     fs.readFile fileName, (err, xmlData) ->


### PR DESCRIPTION
dates are not built into the xml. they are just ignored...