### PR TITLE
Update test result for latest xmlbuilder

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies" : {
     "sax" : "0.6.x",
-    "xmlbuilder" : ">=1.0.0"
+    "xmlbuilder" : ">=2.4.6"
   },
   "devDependencies" : {
     "coffee-script" : ">=1.7.1",

--- a/test/builder.test.coffee
+++ b/test/builder.test.coffee
@@ -18,7 +18,7 @@ diffeq = (expected, actual) ->
 
 module.exports =
   'test building basic XML structure': (test) ->
-    expected = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xml><Label></Label><MsgId>5850440872586764820</MsgId></xml>'
+    expected = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xml><Label/><MsgId>5850440872586764820</MsgId></xml>'
     obj = {"xml":{"Label":[""],"MsgId":["5850440872586764820"]}}
     builder = new xml2js.Builder renderOpts: pretty: false
     actual = builder.buildObject obj


### PR DESCRIPTION
The latest xmlbuilder (2.4.6) outputs tags with no children in compact form, as `<Label/>` instead of `<Label></Label>`, which is causing one of the tests to fail.

This PR updates the minimum required version of xmlbuilder along with the test results.

The alternative, if you still want to support the older xmlbuilder, would be to accept both results.

I guess #166 also overlaps with this?
