### PR TITLE
valueProcessors Should Also Process Attribute Values

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -306,7 +306,7 @@
               if (!(attrkey in obj) && !_this.options.mergeAttrs) {
                 obj[attrkey] = {};
               }
-              newValue = node.attributes[key];
+              newValue = _this.options.valueProcessors ? processName(_this.options.valueProcessors, node.attributes[key]) : node.attributes[key];
               processedKey = _this.options.attrNameProcessors ? processName(_this.options.attrNameProcessors, key) : key;
               if (_this.options.mergeAttrs) {
                 _this.assignOrPush(obj, processedKey, newValue);

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -254,7 +254,7 @@ class exports.Parser extends events.EventEmitter
         for own key of node.attributes
           if attrkey not of obj and not @options.mergeAttrs
             obj[attrkey] = {}
-          newValue = node.attributes[key]
+          newValue = if @options.valueProcessors then processName(@options.valueProcessors, node.attributes[key]) else node.attributes[key]
           processedKey = if @options.attrNameProcessors then processName(@options.attrNameProcessors, key) else key
           if @options.mergeAttrs
             @assignOrPush obj, processedKey, newValue

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -419,11 +419,13 @@ module.exports =
 
   'test single valueProcessor': skeleton(valueProcessors: [nameToUpperCase], (r)->
     console.log 'Result object: ' + util.inspect r, false, 10
-    equ r.sample.valueProcessTest[0], 'SOME VALUE')
+    equ r.sample.valueProcessTest[0], 'SOME VALUE'
+    equ r.sample.chartest[0].$.desc, 'TEST FOR CHARS')
 
   'test multiple valueProcessor': skeleton(valueProcessors: [nameToUpperCase, nameCutoff], (r)->
     console.log 'Result object: ' + util.inspect r, false, 10
-    equ r.sample.valueProcessTest[0], 'SOME')
+    equ r.sample.valueProcessTest[0], 'SOME'
+    equ r.sample.chartest[0].$.desc, 'TEST')
 
   'test single tagNameProcessors': skeleton(tagNameProcessors: [nameToUpperCase], (r)->
     console.log 'Result object: ' + util.inspect r, false, 10


### PR DESCRIPTION
While trying to use the parseNumbers processor, I've noticed it wasn't working. Digging it, I've found out it didn't process attributes' values. This fixes that.

If this isn't supposed to be the default behaviour, then maybe the documentation needs to be clearer.

/cc @rochal 