### PR TITLE
Fix cdata issue on non-strings

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -187,7 +187,7 @@
               } else if (typeof child === "object") {
                 element = arguments.callee(element.ele(key), child).up();
               } else {
-                if (_this.options.cdata && requiresCDATA(child)) {
+                if (typeof child === 'string' && _this.options.cdata && requiresCDATA(child)) {
                   element = element.ele(key).raw(wrapCDATA(child)).up();
                 } else {
                   element = element.ele(key, child.toString()).up();

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -162,7 +162,7 @@ class exports.Builder
 
           # Case #5 String and remaining types
           else
-            if @options.cdata && requiresCDATA child
+            if typeof child is 'string' && @options.cdata && requiresCDATA child
               element = element.ele(key).raw(wrapCDATA child).up()
             else
               element = element.ele(key, child.toString()).up()

--- a/test/builder.test.coffee
+++ b/test/builder.test.coffee
@@ -201,3 +201,18 @@ module.exports =
     actual = builder.buildObject obj
     diffeq expected, actual
     test.finish()
+
+  'test does not error on non string values when checking for cdata': (test) ->
+    expected = """
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <xml>
+        <MsgId>10</MsgId>
+      </xml>
+
+    """
+    opts = cdata: true
+    builder = new xml2js.Builder opts
+    obj = {"xml":{"MsgId":10}}
+    actual = builder.buildObject obj
+    diffeq expected, actual
+    test.finish()


### PR DESCRIPTION
Prior to this commit any attempt to build xml with a value that was not
a string would eventually cause an indexOf error when checking if there
was a cdata requirement. Below is an example with the error that it
generates.

The example:

    var xml2js = require('xml2js');
    var obj = {name: "Super", Surname: "Man > Woman", age: 23};
    var builder = new xml2js.Builder({cdata: true});
    var xml = builder.buildObject(obj);
    console.log(xml);

and the error:

    xml2js/lib/xml2js.js:32
    return entry.indexOf('&') >= 0 || entry.indexOf('>') >= 0 || entry.indexOf

    TypeError: undefined is not a function

The fix is to simply check that it is a string before checking that it
requires cdata.