### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,10 +62,5 @@
     "docco" : ">=0.6.2",
     "diff" : ">=1.0.8"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://raw.github.com/Leonidas-from-XIV/node-xml2js/master/LICENSE"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/