### PR TITLE
adds coverage reporting with nyc and coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.swp
 node_modules
 npm-debug.log
+.nyc_output
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ node_js:
   - "0.10"
   - "0.12"
   - iojs
+
+after_success: npm run coveralls

--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ Running tests, development
 ==========================
 
 [![Build Status](https://secure.travis-ci.org/Leonidas-from-XIV/node-xml2js.png?branch=master)](https://travis-ci.org/Leonidas-from-XIV/node-xml2js)
+[![Coverage Status](https://coveralls.io/repos/Leonidas-from-XIV/node-xml2js/badge.svg?branch=)](https://coveralls.io/r/Leonidas-from-XIV/node-xml2js?branch=master)
 [![Dependency Status](https://david-dm.org/Leonidas-from-XIV/node-xml2js.png)](https://david-dm.org/Leonidas-from-XIV/node-xml2js)
 
 The development requirements are handled by npm, you just need to install them.

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
-  "name" : "xml2js",
-  "description" : "Simple XML to JavaScript object converter.",
-  "keywords" : ["xml", "json"],
-  "homepage" : "https://github.com/Leonidas-from-XIV/node-xml2js",
-  "version" : "0.4.8",
-  "author" : "Marek Kubica <marek@xivilization.net> (http://xivilization.net)",
-  "contributors" : [
+  "name": "xml2js",
+  "description": "Simple XML to JavaScript object converter.",
+  "keywords": [
+    "xml",
+    "json"
+  ],
+  "homepage": "https://github.com/Leonidas-from-XIV/node-xml2js",
+  "version": "0.4.8",
+  "author": "Marek Kubica <marek@xivilization.net> (http://xivilization.net)",
+  "contributors": [
     "maqr <maqr.lollerskates@gmail.com> (https://github.com/maqr)",
     "Ben Weaver (http://benweaver.com/)",
     "Jae Kwon (https://github.com/jaekwon)",
@@ -41,26 +44,30 @@
     "Ryan Gahl (https://github.com/ryedin)",
     "Eric Laberge <e.laberge@gmail.com> (https://github.com/elaberge)"
   ],
-  "main" : "./lib/xml2js",
-  "directories" : {
+  "main": "./lib/xml2js",
+  "directories": {
     "lib": "./lib"
   },
-  "scripts" : {
-    "test": "zap"
+  "scripts": {
+    "test": "zap",
+    "coverage": "nyc npm test && nyc report",
+    "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls"
   },
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/Leonidas-from-XIV/node-xml2js.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Leonidas-from-XIV/node-xml2js.git"
   },
-  "dependencies" : {
-    "sax" : "0.6.x",
-    "xmlbuilder" : ">=2.4.6"
+  "dependencies": {
+    "sax": "0.6.x",
+    "xmlbuilder": ">=2.4.6"
   },
-  "devDependencies" : {
-    "coffee-script" : ">=1.9.0",
-    "zap" : ">=0.2.6",
-    "docco" : ">=0.6.2",
-    "diff" : ">=1.0.8"
+  "devDependencies": {
+    "coffee-script": ">=1.9.0",
+    "coveralls": "^2.11.2",
+    "diff": ">=1.0.8",
+    "docco": ">=0.6.2",
+    "nyc": "^2.2.1",
+    "zap": ">=0.2.6"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
This pull adds coverage reporting, using coveralls.io and the [nyc](https://www.npmjs.com/package/nyc) instrumenter.

* run `npm run coverage` to get a human readable coverage report.
* run `npm run coverage -- --reporter=lcov` to get an HTML report over coverage in the /coverage folder.
* run `npm run coveralls` to report coverage to the [coveralls.io](https://coveralls.io/).
  * you'll need to setup your repo on coveralls.io and grap the `COVERALLS_REPO_TOKEN`.
  * on travis-ci.org, you'll need to set an environment variable with the value of `COVERALLS_REPO_TOKEN `

Here's the current state of things:

```shell
--------------------|-----------|-----------|-----------|-----------|
File                |   % Stmts |% Branches |   % Funcs |   % Lines |
--------------------|-----------|-----------|-----------|-----------|
   lib/             |     94.58 |     86.17 |       100 |     96.83 |
      bom.js        |       100 |       100 |       100 |       100 |
      processors.js |       100 |        75 |       100 |       100 |
      xml2js.js     |     94.23 |     86.26 |       100 |     96.61 |
--------------------|-----------|-----------|-----------|-----------|
All files           |     94.58 |     86.17 |       100 |     96.83 |
--------------------|-----------|-----------|-----------|-----------|
```