### PR TITLE
Fix chaining w/ processors that don't return strings

### DIFF
--- a/lib/processors.js
+++ b/lib/processors.js
@@ -5,11 +5,19 @@
   prefixMatch = new RegExp(/(?!xmlns)^.*:/);
 
   exports.normalize = function(str) {
-    return str.toLowerCase();
+    if (typeof str === 'string') {
+      return str.toLowerCase();
+    } else {
+      return str;
+    }
   };
 
   exports.firstCharLowerCase = function(str) {
-    return str.charAt(0).toLowerCase() + str.slice(1);
+    if (typeof str === 'string') {
+      return str.charAt(0).toLowerCase() + str.slice(1);
+    } else {
+      return str;
+    }
   };
 
   exports.stripPrefix = function(str) {
@@ -17,10 +25,11 @@
   };
 
   exports.parseNumbers = function(str) {
-    if (!isNaN(str)) {
-      str = str % 1 === 0 ? parseInt(str, 10) : parseFloat(str);
+    if (typeof str === 'string' && !isNaN(str)) {
+      return str = str % 1 === 0 ? parseInt(str, 10) : parseFloat(str);
+    } else {
+      return str;
     }
-    return str;
   };
 
 }).call(this);

--- a/src/processors.coffee
+++ b/src/processors.coffee
@@ -2,15 +2,22 @@
 prefixMatch = new RegExp /(?!xmlns)^.*:/
 
 exports.normalize = (str) ->
-  return str.toLowerCase()
+  if typeof str is 'string'
+    return str.toLowerCase()
+  else
+    return str
 
 exports.firstCharLowerCase = (str) ->
-  return str.charAt(0).toLowerCase() + str.slice(1)
+  if typeof str is 'string'
+    return str.charAt(0).toLowerCase() + str.slice(1)
+  else
+    return str
 
 exports.stripPrefix = (str) ->
   return str.replace prefixMatch, ''
 
 exports.parseNumbers = (str) ->
-  if !isNaN str
+  if typeof str is 'string' and !isNaN str
     str = if str % 1 == 0 then parseInt str, 10 else parseFloat str
-  return str
+  else
+    return str

--- a/test/processors.test.coffee
+++ b/test/processors.test.coffee
@@ -7,12 +7,16 @@ module.exports =
     demo = 'This shOUld BE loWErcase'
     result = processors.normalize demo
     equ result, 'this should be lowercase'
+    equ processors.normalize(false), false
+    equ processors.normalize(123), 123
     test.done()
 
   'test firstCharLowerCase': (test) ->
     demo = 'ThiS SHould OnlY LOwercase the fIRST cHar'
     result = processors.firstCharLowerCase demo
     equ result, 'thiS SHould OnlY LOwercase the fIRST cHar'
+    equ processors.firstCharLowerCase(false), false
+    equ processors.firstCharLowerCase(123), 123
     test.done()
 
   'test stripPrefix': (test) ->
@@ -32,4 +36,7 @@ module.exports =
     equ processors.parseNumbers('123'), 123
     equ processors.parseNumbers('15.56'), 15.56
     equ processors.parseNumbers('10.00'), 10
+    equ processors.parseNumbers(false), false
+    equ processors.parseNumbers(true), true
+    equ processors.parseNumbers("foobar"), "foobar"
     test.done()


### PR DESCRIPTION
If using one of the built-in processors w/ a processor that
does not return a string, they'd break because they always
expect a string as input. While it is possible to workaround
this problem by adjusting the order in which processors get
executed, I think this is a nicer solution.