### PR TITLE
Add explicitAttrs option to always include attrkey

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -76,6 +76,7 @@
       explicitArray: true,
       ignoreAttrs: false,
       mergeAttrs: false,
+      explicitAttrs: false,
       explicitRoot: true,
       validator: null,
       xmlns: false,
@@ -305,6 +306,9 @@
           obj = {};
           obj[charkey] = "";
           if (!_this.options.ignoreAttrs) {
+            if (_this.options.explicitAttrs && !(attrkey in obj)) {
+              obj[attrkey] = {};
+            }
             ref = node.attributes;
             for (key in ref) {
               if (!hasProp.call(ref, key)) continue;

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -74,6 +74,8 @@ exports.defaults =
     explicitArray: true
     ignoreAttrs: false
     mergeAttrs: false
+    # Define attrkey on each node as an empty object even if no attributes
+    explicitAttrs: false
     explicitRoot: true
     validator: null
     xmlns : false
@@ -255,6 +257,8 @@ class exports.Parser extends events.EventEmitter
       obj = {}
       obj[charkey] = ""
       unless @options.ignoreAttrs
+        if @options.explicitAttrs and attrkey not of obj
+          obj[attrkey] = {}
         for own key of node.attributes
           if attrkey not of obj and not @options.mergeAttrs
             obj[attrkey] = {}

--- a/test/fixtures/sample.xml
+++ b/test/fixtures/sample.xml
@@ -54,4 +54,5 @@
     <tagNameProcessTest/>
     <valueProcessTest>some value</valueProcessTest>
     <textordertest>this is text with <b>markup</b> in the middle</textordertest>
+    <noAttributes/>
 </sample>

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -107,6 +107,11 @@ module.exports =
     equ r.sample.listtest[0].single[0], 'Single'
     equ r.sample.listtest[0].attr[0], 'Attribute')
 
+  'test parse with explicitAttrs': skeleton(explicitAttrs: true, (r) ->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    equ typeof r.sample.noAttributes[0].$, 'object'
+    equ Object.keys(r.sample.noAttributes[0].$).length, 0)
+
   'test parse with mergeAttrs and not explicitArray': skeleton(mergeAttrs: true, explicitArray: false, (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10
     equ r.sample.chartest.desc, 'Test for CHARs'


### PR DESCRIPTION
By default, if no attributes are defined on a node, the attrkey on the output is undefined. This defines the attrkey as an empty object even if the node has no attributes.