### PR TITLE
Fixed missing return statement

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -474,7 +474,7 @@
         if (this.options.async) {
           this.remaining = str;
           setImmediate(this.processAsync);
-          this.saxParser;
+          return this.saxParser;
         }
         return this.saxParser.write(str).close();
       } catch (_error) {

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -392,7 +392,7 @@ class exports.Parser extends events.EventEmitter
       if @options.async
         @remaining = str
         setImmediate @processAsync
-        @saxParser
+        return @saxParser
       @saxParser.write(str).close()
     catch err
       unless @saxParser.errThrown or @saxParser.ended


### PR DESCRIPTION
For `async: true`, this was causing the parser to run twice - once sync, then once async.

This causes issues with calling libraries such as express-xml-bodyparser.