### PR TITLE
fix browserify support for async parsing

### DIFF
--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -5,6 +5,7 @@ events = require 'events'
 builder = require 'xmlbuilder'
 bom = require './bom'
 processors = require './processors'
+global.setImmediate = require('timers').setImmediate
 
 # Underscore has a nice function for this, but we try to go without dependencies
 isEmpty = (thing) ->

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -5,7 +5,7 @@ events = require 'events'
 builder = require 'xmlbuilder'
 bom = require './bom'
 processors = require './processors'
-global.setImmediate = require('timers').setImmediate
+setImmediate = require('timers').setImmediate
 
 # Underscore has a nice function for this, but we try to go without dependencies
 isEmpty = (thing) ->


### PR DESCRIPTION
setImmediate is not a ecmascript standard function and Browserify doesn't support it.

See https://github.com/substack/node-browserify/issues/985#issuecomment-62963011

when setting ```{ async: true }``` in the browser, the parser fails due to setImmediate not being defined