### PR TITLE
catch async errors, squelch if already emitted

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -250,16 +250,23 @@
 
     Parser.prototype.processAsync = function() {
       var chunk;
-      if (this.remaining.length <= this.options.chunkSize) {
-        chunk = this.remaining;
-        this.remaining = '';
-        this.saxParser = this.saxParser.write(chunk);
-        return this.saxParser.close();
-      } else {
-        chunk = this.remaining.substr(0, this.options.chunkSize);
-        this.remaining = this.remaining.substr(this.options.chunkSize, this.remaining.length);
-        this.saxParser = this.saxParser.write(chunk);
-        return setImmediate(this.processAsync);
+      try {
+        if (this.remaining.length <= this.options.chunkSize) {
+          chunk = this.remaining;
+          this.remaining = '';
+          this.saxParser = this.saxParser.write(chunk);
+          return this.saxParser.close();
+        } else {
+          chunk = this.remaining.substr(0, this.options.chunkSize);
+          this.remaining = this.remaining.substr(this.options.chunkSize, this.remaining.length);
+          this.saxParser = this.saxParser.write(chunk);
+          return setImmediate(this.processAsync);
+        }
+      } catch(err) {
+        if (!this.saxParser.errThrown) {
+          this.saxParser.errThrown = true;
+          this.emit('error', err);
+        }
       }
     };
 

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -198,16 +198,21 @@ class exports.Parser extends events.EventEmitter
     @reset()
 
   processAsync: =>
-    if @remaining.length <= @options.chunkSize
-      chunk = @remaining
-      @remaining = ''
-      @saxParser = @saxParser.write chunk
-      @saxParser.close()
-    else
-      chunk = @remaining.substr 0, @options.chunkSize
-      @remaining = @remaining.substr @options.chunkSize, @remaining.length
-      @saxParser = @saxParser.write chunk
-      setImmediate @processAsync
+    try
+      if @remaining.length <= @options.chunkSize
+        chunk = @remaining
+        @remaining = ''
+        @saxParser = @saxParser.write chunk
+        @saxParser.close()
+      else
+        chunk = @remaining.substr 0, @options.chunkSize
+        @remaining = @remaining.substr @options.chunkSize, @remaining.length
+        @saxParser = @saxParser.write chunk
+        setImmediate @processAsync
+    catch err
+      if ! @saxParser.errThrown
+        @saxParser.errThrown = true
+        @emit err
 
   assignOrPush: (obj, key, newValue) =>
     if key not of obj

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -369,7 +369,7 @@ module.exports =
       # Make sure no future changes break this
       ++nCalled
       if nCalled > 1
-        throw new Error 'callback called multiple times'
+        test.fail 'callback called multiple times'
       # SAX Parser throws multiple errors when processing async. We need to catch and return the first error
       # and then squelch the rest. The only way to test this is to defer the test finish call until after the
       # current stack processes, which, if the test would fail, would contain and throw the additional errors

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -362,6 +362,19 @@ module.exports =
       equ e.message, 'error throwing in callback'
       test.finish()
 
+  'test error throwing after an error (async)': (test) ->
+    xml = '<?xml version="1.0" encoding="utf-8"?><test node is not okay>content is ok</test node is not okay>'
+    nCalled = 0
+    xml2js.parseString xml, async: true, (err, parsed) ->
+      # Make sure no future changes break this
+      ++nCalled
+      if nCalled > 1
+        throw new Error 'callback called multiple times'
+      # SAX Parser throws multiple errors when processing async. We need to catch and return the first error
+      # and then squelch the rest. The only way to test this is to defer the test finish call until after the
+      # current stack processes, which, if the test would fail, would contain and throw the additional errors
+      setTimeout test.finish.bind test
+
   'test xmlns': skeleton(xmlns: true, (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10
     equ r.sample["pfx:top"][0].$ns.local, 'top'


### PR DESCRIPTION
This fixes #239 and #232.

I was able to find a better way to handle this.

Passes all tests. New test fails without patch.

(Sorry for the delay, been busy)