### PR TITLE
fix building an object with a property value of undefined or null

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -194,7 +194,7 @@
                 if (typeof child === 'string' && _this.options.cdata && requiresCDATA(child)) {
                   element = element.ele(key).raw(wrapCDATA(child)).up();
                 } else {
-                  if (child === undefined || child === null) {
+                  if (child === void 0 || child === null) {
                     child = '';
                   }
                   element = element.ele(key, child.toString()).up();

--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -194,6 +194,9 @@
                 if (typeof child === 'string' && _this.options.cdata && requiresCDATA(child)) {
                   element = element.ele(key).raw(wrapCDATA(child)).up();
                 } else {
+                  if (child === undefined || child === null) {
+                    child = '';
+                  }
                   element = element.ele(key, child.toString()).up();
                 }
               }

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -169,6 +169,8 @@ class exports.Builder
             if typeof child is 'string' && @options.cdata && requiresCDATA child
               element = element.ele(key).raw(wrapCDATA child).up()
             else
+              if child === undefined || child === null
+                child = ''
               element = element.ele(key, child.toString()).up()
 
       element

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -169,7 +169,7 @@ class exports.Builder
             if typeof child is 'string' && @options.cdata && requiresCDATA child
               element = element.ele(key).raw(wrapCDATA child).up()
             else
-              if child === undefined || child === null
+              if child is undefined or child is null
                 child = ''
               element = element.ele(key, child.toString()).up()
 

--- a/test/builder.test.coffee
+++ b/test/builder.test.coffee
@@ -127,6 +127,22 @@ module.exports =
         diffeq xmlExpected, xmlActual
         test.finish()
 
+  'test building obj with undefined value' : (test) ->
+    obj = { node: 'string', anothernode: undefined }
+    builder = new xml2js.Builder renderOpts: { pretty: false }
+    actual = builder.buildObject(obj);
+    expected = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><root><node>string</node><anothernode/></root>'
+    equ actual, expected
+    test.finish();
+
+  'test building obj with null value' : (test) ->
+    obj = { node: 'string', anothernode: null }
+    builder = new xml2js.Builder renderOpts: { pretty: false }
+    actual = builder.buildObject(obj);
+    expected = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><root><node>string</node><anothernode/></root>'
+    equ actual, expected
+    test.finish();
+
   'test escapes escaped characters': (test) ->
     expected = """
       <?xml version="1.0" encoding="UTF-8" standalone="yes"?>


### PR DESCRIPTION
This fixes trying to build an object with an undefined or null value by setting the value to an empty string.

IE:
```javascript
{ firstnode: 'string', secondnode: undefined }
// or
{ firstnode: 'string', secondnode: null }
```

Yields:
```xml
<firstnode>string</firstnode><secondnode/>
```

Instead of failing with an uncaught exception of

```TypeError: Cannot read property 'toString' of undefined.```
or
```TypeError: Cannot read property 'toString' of null.```