### PR TITLE
Added attrValueProcessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ parseString(xml, {
 });
 ```
 
-The `tagNameProcessors`, `attrNameProcessors`, 'attrValueProcessors' and `valueProcessors` options
+The `tagNameProcessors`, `attrNameProcessors`, `attrValueProcessors` and `valueProcessors` options
 accept an `Array` of functions with the following signature:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ option to `true`.
 Processing attribute, tag names and values
 ------------------------------------------
 
-Since 0.4.1 you can optionally provide the parser with attribute and tag name processors as well as values:
+Since 0.4.1 you can optionally provide the parser with attribute name and tag name processors as well as element value processors (Since 0.4.14, you can also optionally provide the parser with attribute value processors):
 
 ```javascript
 
@@ -185,17 +185,18 @@ function nameToUpperCase(name){
     return name.toUpperCase();
 }
 
-//transform all attribute and tag names to uppercase
+//transform all attribute and tag names and values to uppercase
 parseString(xml, {
   tagNameProcessors: [nameToUpperCase],
   attrNameProcessors: [nameToUpperCase],
-  valueProcessors: [nameToUpperCase]},
+  valueProcessors: [nameToUpperCase],
+  attrValueProcessors: [nameToUpperCase]},
   function (err, result) {
     // processed data
 });
 ```
 
-The `tagNameProcessors`, `attrNameProcessors` and `valueProcessors` options
+The `tagNameProcessors`, `attrNameProcessors`, 'attrValueProcessors' and `valueProcessors` options
 accept an `Array` of functions with the following signature:
 
 ```javascript
@@ -285,6 +286,16 @@ value})``. Possible options are:
         return name
     }
     ```
+    Added in 0.4.14
+  * `attrValueProcessors` (default: `null`): Allows the addition of attribute
+    value processing functions. Accepts an `Array` of functions with following
+    signature:
+    ```javascript
+    function (name){
+      //do something with `name`
+      return name
+    }
+    ```
     Added in 0.4.1
   * `tagNameProcessors` (default: `null`): Allows the addition of tag name
     processing functions. Accepts an `Array` of functions with following
@@ -296,7 +307,7 @@ value})``. Possible options are:
     }
     ```
     Added in 0.4.1
-  * `valueProcessors` (default: `null`): Allows the addition of value
+  * `valueProcessors` (default: `null`): Allows the addition of element value
     processing functions. Accepts an `Array` of functions with following
     signature:
     ```javascript

--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -65,6 +65,7 @@
       async: false,
       strict: true,
       attrNameProcessors: null,
+      attrValueProcessors: null,
       tagNameProcessors: null,
       valueProcessors: null,
       emptyTag: ''
@@ -89,6 +90,7 @@
       async: false,
       strict: true,
       attrNameProcessors: null,
+      attrValueProcessors: null,
       tagNameProcessors: null,
       valueProcessors: null,
       rootName: 'root',
@@ -333,7 +335,7 @@
               if (!(attrkey in obj) && !_this.options.mergeAttrs) {
                 obj[attrkey] = {};
               }
-              newValue = node.attributes[key];
+              newValue = _this.options.attrValueProcessors ? processName(_this.options.attrValueProcessors, node.attributes[key]) : node.attributes[key];
               processedKey = _this.options.attrNameProcessors ? processName(_this.options.attrNameProcessors, key) : key;
               if (_this.options.mergeAttrs) {
                 _this.assignOrPush(obj, processedKey, newValue);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "json"
   ],
   "homepage": "https://github.com/Leonidas-from-XIV/node-xml2js",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "author": "Marek Kubica <marek@xivilization.net> (https://xivilization.net)",
   "contributors": [
     "maqr <maqr.lollerskates@gmail.com> (https://github.com/maqr)",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "json"
   ],
   "homepage": "https://github.com/Leonidas-from-XIV/node-xml2js",
-  "version": "0.4.14",
+  "version": "0.4.13",
   "author": "Marek Kubica <marek@xivilization.net> (https://xivilization.net)",
   "contributors": [
     "maqr <maqr.lollerskates@gmail.com> (https://github.com/maqr)",
@@ -47,7 +47,8 @@
     "Stephen Cresswell (https://github.com/cressie176)",
     "Pascal Ehlert <pascal@hacksrus.net> (http://www.hacksrus.net/)",
     "Tom Spencer <fiznool@gmail.com> (http://fiznool.com/)",
-    "Tristian Flanagan <tflanagan@datacollaborative.com> (https://github.com/tflanagan)"
+    "Tristian Flanagan <tflanagan@datacollaborative.com> (https://github.com/tflanagan)",
+    "Tim Johns <timjohns@yahoo.com> (https://github.com/TimJohns)"
   ],
   "main": "./lib/xml2js",
   "directories": {

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -63,6 +63,7 @@ exports.defaults =
     async: false
     strict: true
     attrNameProcessors: null
+    attrValueProcessors: null
     tagNameProcessors: null
     valueProcessors: null
     emptyTag: ''
@@ -88,6 +89,7 @@ exports.defaults =
     async: false
     strict: true
     attrNameProcessors: null
+    attrValueProcessors: null
     tagNameProcessors: null
     valueProcessors: null
     # xml building options
@@ -273,7 +275,7 @@ class exports.Parser extends events.EventEmitter
         for own key of node.attributes
           if attrkey not of obj and not @options.mergeAttrs
             obj[attrkey] = {}
-          newValue = node.attributes[key]
+          newValue = if @options.attrValueProcessors then processName(@options.attrValueProcessors, node.attributes[key]) else node.attributes[key]
           processedKey = if @options.attrNameProcessors then processName(@options.attrNameProcessors, key) else key
           if @options.mergeAttrs
             @assignOrPush obj, processedKey, newValue

--- a/test/fixtures/sample.xml
+++ b/test/fixtures/sample.xml
@@ -50,7 +50,8 @@
     <pfx:top xmlns:pfx="http://foo.com" pfx:attr="baz">
         <middle xmlns="http://bar.com"/>
     </pfx:top>
-    <attrNameProcessTest camelCaseAttr="camelCaseAttrValue" lowercaseattr="lowercaseattr" />
+    <attrNameProcessTest camelCaseAttr="camelCaseAttrValue" lowercaseattr="lowercaseattrvalue" />
+    <attrValueProcessTest camelCaseAttr="camelCaseAttrValue" lowerCaseAttr="lowercaseattrvalue" />
     <tagNameProcessTest/>
     <valueProcessTest>some value</valueProcessTest>
     <textordertest>this is text with <b>markup</b> in the middle</textordertest>

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -178,13 +178,13 @@ module.exports =
     equ r.sample.$$[10].$$[5]._, '6'
 
     # test text ordering with XML nodes in the middle
-    equ r.sample.$$[16]['#name'], 'textordertest'
-    equ r.sample.$$[16].$$[0]['#name'], '__text__'
-    equ r.sample.$$[16].$$[0]._, 'this is text with '
-    equ r.sample.$$[16].$$[1]['#name'], 'b'
-    equ r.sample.$$[16].$$[1]._, 'markup'
-    equ r.sample.$$[16].$$[2]['#name'], '__text__'
-    equ r.sample.$$[16].$$[2]._, ' in the middle')
+    equ r.sample.$$[17]['#name'], 'textordertest'
+    equ r.sample.$$[17].$$[0]['#name'], '__text__'
+    equ r.sample.$$[17].$$[0]._, 'this is text with '
+    equ r.sample.$$[17].$$[1]['#name'], 'b'
+    equ r.sample.$$[17].$$[1]._, 'markup'
+    equ r.sample.$$[17].$$[2]['#name'], '__text__'
+    equ r.sample.$$[17].$$[2]._, ' in the middle')
 
   'test element without children': skeleton(explicitChildren: true, (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10
@@ -507,6 +507,16 @@ module.exports =
     console.log 'Result object: ' + util.inspect r, false, 10
     equ r.sample.attrNameProcessTest[0].$.hasOwnProperty('CAME'), true
     equ r.sample.attrNameProcessTest[0].$.hasOwnProperty('LOWE'), true)
+
+  'test single attrValueProcessors': skeleton(attrValueProcessors: [nameToUpperCase], (r)->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    equ r.sample.attrValueProcessTest[0].$.camelCaseAttr, 'CAMELCASEATTRVALUE'
+    equ r.sample.attrValueProcessTest[0].$.lowerCaseAttr, 'LOWERCASEATTRVALUE')
+
+  'test multiple attrValueProcessors': skeleton(attrValueProcessors: [nameToUpperCase, nameCutoff], (r)->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    equ r.sample.attrValueProcessTest[0].$.camelCaseAttr, 'CAME'
+    equ r.sample.attrValueProcessTest[0].$.lowerCaseAttr, 'LOWE')
 
   'test single valueProcessor': skeleton(valueProcessors: [nameToUpperCase], (r)->
     console.log 'Result object: ' + util.inspect r, false, 10


### PR DESCRIPTION
 The existing processors were (optionally) applied to attribute names, tag names, and element values, but not to attribute values.   

This PR adds the option to include a processor that will be applied to attribute values.  I needed this functionality in order to facilitate compatibility with xml2json, where numerical attribute values were processed into floats and integers.

I would anticipate this PR also addresses Issue #198.
