### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ value})``. Possible options are:
 Options for the `Builder` class
 -------------------------------
 
-  * `rootName` (default `root`): root element name to be used in case
+  * `rootName` (default `root` or the name of the root key of the object to build): root element name to be used in case
      `explicitRoot` is `false` or to override the root element name.
   * `renderOpts` (default `{ 'pretty': true, 'indent': '  ', 'newline': '\n' }`):
     Rendering options for xmlbuilder-js.

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ value})``. Possible options are:
 Options for the `Builder` class
 -------------------------------
 
-  * `rootName` (default `root` or the name of the root key of the object to build): root element name to be used in case
+  * `rootName` (default `root` or the root key name): root element name to be used in case
      `explicitRoot` is `false` or to override the root element name.
   * `renderOpts` (default `{ 'pretty': true, 'indent': '  ', 'newline': '\n' }`):
     Rendering options for xmlbuilder-js.


### PR DESCRIPTION
The default `rootName` is not always `root`. It is only when the Javascript object to build doesn't have a hierarchy (all other keys nested under a root key).