### PR TITLE
Add allowSurrogateChars option passthrough to xmlbuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ Options for the `Builder` class
     * `xmldec.standalone` standalone document declaration: true or false
   * `doctype` (default `null`): optional DTD. Eg. `{'ext': 'hello.dtd'}`
   * `headless` (default: `false`): omit the XML header. Added in 0.4.3.
+  * `allowSurrogateChars` (default: `false`): allows using characters from the Unicode
+    surrogate blocks.
   * `cdata` (default: `false`): wrap text nodes in `<![CDATA[ ... ]]>` instead of
     escaping when necessary. Does not add `<![CDATA[ ... ]]>` if it is not required.
     Added in 0.4.5.

--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -208,7 +208,8 @@
         };
       })(this);
       rootElement = builder.create(rootName, this.options.xmldec, this.options.doctype, {
-        headless: this.options.headless
+        headless: this.options.headless,
+        allowSurrogateChars: this.options.allowSurrogateChars
       });
       return render(rootElement, rootObj).end(this.options.renderOpts);
     };

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -178,7 +178,8 @@ class exports.Builder
       element
 
     rootElement = builder.create(rootName, @options.xmldec, @options.doctype,
-      headless: @options.headless)
+      headless: @options.headless
+      allowSurrogateChars: @options.allowSurrogateChars)
 
     render(rootElement, rootObj).end(@options.renderOpts)
 

--- a/test/builder.test.coffee
+++ b/test/builder.test.coffee
@@ -80,6 +80,23 @@ module.exports =
     diffeq expected, actual
     test.finish()
 
+  'test allowSurrogateChars option': (test) ->
+    expected = """
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <xml>
+          <MsgId>\uD83D\uDC33</MsgId>
+      </xml>
+
+    """
+    opts =
+      renderOpts: pretty: true, indent: '    '
+      allowSurrogateChars: true
+    builder = new xml2js.Builder opts
+    obj = {"xml":{"MsgId":["\uD83D\uDC33"]}}
+    actual = builder.buildObject obj
+    diffeq expected, actual
+    test.finish()
+
   'test explicit rootName is always used: 1. when there is only one element': (test) ->
     expected = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><FOO><MsgId>5850440872586764820</MsgId></FOO>'
     opts = renderOpts: {pretty: false}, rootName: 'FOO'


### PR DESCRIPTION
As with the `headless` option, this change adds support to pass the `allowSurrogateChars` options to the builder (see: https://github.com/oozcitak/xmlbuilder-js/wiki)

Addresses #221.