### PR TITLE
Feature/simple content without array

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,9 @@ value})``. Possible options are:
     }
     ```
     Added in 0.4.6
+  * `flattenSimpleContent` (default: `false`): Don't create an array for
+    child nodes with simple content and no attributes if true, even if 
+    `explicitArray` is true.
 
 Options for the `Builder` class
 -------------------------------

--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -277,8 +277,19 @@
     };
 
     Parser.prototype.assignOrPush = function(obj, key, newValue) {
+      var hasAttributes, hasComplexContent, shouldFlatten;
+      hasComplexContent = false;
+      hasAttributes = false;
+      if (newValue) {
+        hasAttributes = !this.options.ignoreAttrs && newValue.hasOwnProperty(this.options.attrkey);
+        if (newValue.hasComplexContent != null) {
+          hasComplexContent = newValue.hasComplexContent;
+          delete newValue.hasComplexContent;
+        }
+      }
+      shouldFlatten = this.options.flattenSimpleContent && !hasComplexContent && !hasAttributes;
       if (!(key in obj)) {
-        if (!this.options.explicitArray) {
+        if (!this.options.explicitArray || shouldFlatten) {
           return obj[key] = newValue;
         } else {
           return obj[key] = [newValue];
@@ -328,6 +339,9 @@
           var key, newValue, obj, processedKey, ref;
           obj = {};
           obj[charkey] = "";
+          if (stack.length > 1) {
+            stack[stack.length - 1].hasComplexContent = true;
+          }
           if (!_this.options.ignoreAttrs) {
             ref = node.attributes;
             for (key in ref) {
@@ -413,6 +427,7 @@
                 node[_this.options.charkey] = obj[_this.options.charkey];
                 delete obj[_this.options.charkey];
               }
+              delete obj.hasComplexContent;
               if (Object.getOwnPropertyNames(obj).length > 0) {
                 node[_this.options.childkey] = obj;
               }

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -543,3 +543,49 @@ module.exports =
     console.log 'Result object: ' + util.inspect r, false, 10
     equ r.hasOwnProperty('SAMP'), true
     equ r.SAMP.hasOwnProperty('TAGN'), true)
+
+  'test parse with flattenSimpleContent': skeleton(flattenSimpleContent: true, (r) ->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    equ r.sample.chartest[0].$.desc, 'Test for CHARs'
+    equ r.sample.chartest[0]._, 'Character data here!'
+    equ r.sample.cdatatest[0].$.desc, 'Test for CDATA'
+    equ r.sample.cdatatest[0].$.misc, 'true'
+    equ r.sample.cdatatest[0]._, 'CDATA here!'
+    equ r.sample.nochartest[0].$.desc, 'No data'
+    equ r.sample.nochartest[0].$.misc, 'false'
+    equ r.sample.listtest[0].item[0]._, '\n            This  is\n            \n            character\n            \n            data!\n            \n        '
+    equ r.sample.listtest[0].item[0].subitem[0], 'Foo(1)'
+    equ r.sample.listtest[0].item[0].subitem[1], 'Foo(2)'
+    equ r.sample.listtest[0].item[0].subitem[2], 'Foo(3)'
+    equ r.sample.listtest[0].item[0].subitem[3], 'Foo(4)'
+    equ r.sample.listtest[0].item[1], 'Qux.'
+    equ r.sample.listtest[0].item[2], 'Quux.'
+    equ r.sample.listtest[0].single, 'Single'
+    equ r.sample.arraytest[0].item[0].subitem, 'Baz.'
+    equ r.sample.emptytest, ''
+    # determine number of items in object
+    equ Object.keys(r.sample.tagcasetest[0]).length, 3
+    equ r.sample.tagcasetest[0].tAg, 'something'
+    equ r.sample.tagcasetest[0].TAG, 'something else'
+    equ r.sample.tagcasetest[0].tag, 'something third')
+
+  'test parse with flattenSimpleContent and ignoreAttrs': skeleton(flattenSimpleContent: true, ignoreAttrs: true, (r) ->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    equ r.sample.chartest, 'Character data here!'
+    equ r.sample.cdatatest, 'CDATA here!'
+    equ r.sample.nochartest, ''
+    equ r.sample.listtest[0].item[0]._, '\n            This  is\n            \n            character\n            \n            data!\n            \n        '
+    equ r.sample.listtest[0].item[0].subitem[0], 'Foo(1)'
+    equ r.sample.listtest[0].item[0].subitem[1], 'Foo(2)'
+    equ r.sample.listtest[0].item[0].subitem[2], 'Foo(3)'
+    equ r.sample.listtest[0].item[0].subitem[3], 'Foo(4)'
+    equ r.sample.listtest[0].item[1], 'Qux.'
+    equ r.sample.listtest[0].item[2], 'Quux.'
+    equ r.sample.listtest[0].single, 'Single'
+    equ r.sample.arraytest[0].item[0].subitem, 'Baz.'
+    equ r.sample.emptytest, ''
+    # determine number of items in object
+    equ Object.keys(r.sample.tagcasetest[0]).length, 3
+    equ r.sample.tagcasetest[0].tAg, 'something'
+    equ r.sample.tagcasetest[0].TAG, 'something else'
+    equ r.sample.tagcasetest[0].tag, 'something third')


### PR DESCRIPTION
My use case is similar to https://github.com/Leonidas-from-XIV/node-xml2js/issues/258 . I would like nodes which contain no child elements or attributes to be written as simple scalars instead of arrays. 

For example, given this xml:

```xml
<sample>
    <complex>
      <child>Some text</child>
    </complex>
    <simple>Some other text</simple>
</sample>
```

The current release of the module would create:

```js
{
  sample: { 
    complex: [ { child: [ 'Some text' ] } ],
    simple: [ 'Some other text' ] 
  } 
}
```

This feature would support the optional creation of this javascript object:

```js
{ 
  sample: { 
    complex: [{ child: 'Some text' }],
    simple: 'Some other text' 
  } 
}
```
This is accomplished by the addition of a new option `flattenSimpleContent`, which is false by default. The feature also supports treating elements with attributes as leaf nodes if the `ignoreAttrs` option is true.

All existing tests pass and I added two tests specifically for this feature.