### PR TITLE
Added arrayForKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ value})``. Possible options are:
   * `emptyTag` (default: `''`): what will the value of empty nodes be.
   * `explicitArray` (default: `true`): Always put child nodes in an array if
     true; otherwise an array is created only if there is more than one.
+  * `arrayForKeys` (default: []): Put child nodes in an array of specified keys.
+    Overides explicitArray: false, on the specified keys. Ex ['key1','key2'].
   * `ignoreAttrs` (default: `false`): Ignore all XML attributes and only create
     text nodes.
   * `mergeAttrs` (default: `false`): Merge attributes and child elements as

--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -4,7 +4,8 @@
   var bom, builder, escapeCDATA, events, isEmpty, processName, processors, requiresCDATA, sax, setImmediate, wrapCDATA,
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty,
-    bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+    bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
+    indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
   sax = require('sax');
 
@@ -54,6 +55,7 @@
       attrkey: "@",
       charkey: "#",
       explicitArray: false,
+      arrayForKeys: [],
       ignoreAttrs: false,
       mergeAttrs: false,
       explicitRoot: false,
@@ -78,6 +80,7 @@
       attrkey: "$",
       charkey: "_",
       explicitArray: true,
+      arrayForKeys: [],
       ignoreAttrs: false,
       mergeAttrs: false,
       explicitRoot: true,
@@ -279,7 +282,7 @@
 
     Parser.prototype.assignOrPush = function(obj, key, newValue) {
       if (!(key in obj)) {
-        if (!this.options.explicitArray) {
+        if (!this.options.explicitArray && indexOf.call(this.options.arrayForKeys, key) < 0) {
           return obj[key] = newValue;
         } else {
           return obj[key] = [newValue];

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -48,6 +48,8 @@ exports.defaults =
     # always put child nodes in an array
     explicitArray: false
     # ignore all attributes regardless
+    arrayForKeys:[]
+    # Put childs as array on a given key. overiding explicitArray: false, on selected keys
     ignoreAttrs: false
     # merge attributes and child elements onto parent object.  this may
     # cause collisions.
@@ -76,6 +78,8 @@ exports.defaults =
     attrkey: "$"
     charkey: "_"
     explicitArray: true
+    arrayForKeys:[]
+    # Put childs as array on a given key. overiding explicitArray: false, on selected keys
     ignoreAttrs: false
     mergeAttrs: false
     explicitRoot: true
@@ -221,7 +225,7 @@ class exports.Parser extends events.EventEmitter
 
   assignOrPush: (obj, key, newValue) =>
     if key not of obj
-      if not @options.explicitArray
+      if not @options.explicitArray and key not in @options.arrayForKeys
         obj[key] = newValue
       else
         obj[key] = [newValue]

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -253,6 +253,18 @@ module.exports =
     equ r.sample.arraytest[0].item[1].subitem[0], 'Foo.'
     equ r.sample.arraytest[0].item[1].subitem[1], 'Bar.')
 
+  'test without arrayForKeys and without explicitArray': skeleton(explicitArray: false, arrayForKeys:[''], (r) ->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    assert.ok r.sample.validatortest['oneitemarray'] not instanceof Array)
+
+  'test arrayForKeys on one tag without explicitArray': skeleton(explicitArray: false, arrayForKeys:['oneitemarray'], (r) ->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    assert.ok r.sample.validatortest['oneitemarray'] instanceof Array)
+    
+  'test arrayForKeys on one tag with explicitArray': skeleton(explicitArray: true, arrayForKeys:['oneitemarray'], (r) ->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    assert.ok r.sample.validatortest[0].oneitemarray instanceof Array)
+
   'test ignore attributes': skeleton(ignoreAttrs: true, (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10
     equ r.sample.chartest[0], 'Character data here!'


### PR DESCRIPTION
Note sure if this is possible by any other function, I couldn't find any other way to do this, but needed this function in a project I am working. Hope my CoffeeScript looks ok, have not coded CoffeeScript before. 

Added function to specify an array of keys (xml tags) and have the children of those nodes be created as an array. This is useful when you want the explicityArray: false behaviour but you also have some children that you want as an array, that in some cases only contain one child.

ex.

xml2json input
explicityArray: false, arrayForKeys:['a1']

XML Data
\<body>\<a1>\<b1>data\</b1>\</a1>\<a2>\<b2>data\</b2>\</a2>\</body>

JSON Result
{"body":{"a1":[{"b1":"data"}],"a2":{"b2":"data"}}}
