### PR TITLE
Exclude Tags if explicit array creation is set to false

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -78,6 +78,7 @@
       attrkey: "$",
       charkey: "_",
       explicitArray: true,
+      explicitArrayExcludes: [],
       ignoreAttrs: false,
       mergeAttrs: false,
       explicitRoot: true,
@@ -280,9 +281,16 @@
     Parser.prototype.assignOrPush = function(obj, key, newValue) {
       if (!(key in obj)) {
         if (!this.options.explicitArray) {
-          return obj[key] = newValue;
+          if(this.options.explicitArrayExcludes.indexOf(key) === -1){
+              return obj[key] = newValue;
+          }else{
+              if (!(obj[key] instanceof Array)) {
+              obj[key] = [obj[key]];
+            }
+              return obj[key].push(newValue);
+            }
         } else {
-          return obj[key] = [newValue];
+             return obj[key] = newValue;
         }
       } else {
         if (!(obj[key] instanceof Array)) {

--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -54,6 +54,7 @@
       attrkey: "@",
       charkey: "#",
       explicitArray: false,
+      explicitArrayExcludes: [],
       ignoreAttrs: false,
       mergeAttrs: false,
       explicitRoot: false,
@@ -281,16 +282,16 @@
     Parser.prototype.assignOrPush = function(obj, key, newValue) {
       if (!(key in obj)) {
         if (!this.options.explicitArray) {
-          if(this.options.explicitArrayExcludes.indexOf(key) === -1){
+          if(this.options.explicitArrayExcludes.indexOf(key) == -1){
               return obj[key] = newValue;
           }else{
               if (!(obj[key] instanceof Array)) {
-              obj[key] = [obj[key]];
-            }
+                obj[key] = [];
+              }
               return obj[key].push(newValue);
-            }
+          }
         } else {
-             return obj[key] = newValue;
+          return obj[key] = [newValue];
         }
       } else {
         if (!(obj[key] instanceof Array)) {


### PR DESCRIPTION
There is no ability to exclude tags from explicit array creation. Sometimes this can be helpful if you dont want to check if the property is an array or not.
**E.g.:**
InvolvedIds: 
   [ { Id: '000011110100001010000100' },
     { Id: '000011110100001001000110' },
     { Id: '000011110100001010000101' } ]

 InvolvedIds: 
   [ { Id: '000011110100001010000100' }]

**In you version it would look like this:**
 InvolvedIds: 
   [ { Id: '000011110100001010000100' },
     { Id: '000011110100001001000110' },
     { Id: '000011110100001010000101' } ]

 InvolvedIds: 
    { Id: '000011110100001010000100' }