### PR TITLE
Added functionality to exclude nodes if explicitArray option is set to false

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -78,6 +78,7 @@
       attrkey: "$",
       charkey: "_",
       explicitArray: true,
+      explicitArrayExcludes: [],
       ignoreAttrs: false,
       mergeAttrs: false,
       explicitRoot: true,
@@ -280,9 +281,16 @@
     Parser.prototype.assignOrPush = function(obj, key, newValue) {
       if (!(key in obj)) {
         if (!this.options.explicitArray) {
-          return obj[key] = newValue;
+          if(this.options.explicitArrayExcludes.indexOf(key) === -1){
+              return obj[key] = newValue;
+          }else{
+              if (!(obj[key] instanceof Array)) {
+              obj[key] = [obj[key]];
+            }
+              return obj[key].push(newValue);
+            }
         } else {
-          return obj[key] = [newValue];
+             return obj[key] = newValue;
         }
       } else {
         if (!(obj[key] instanceof Array)) {

--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -54,6 +54,7 @@
       attrkey: "@",
       charkey: "#",
       explicitArray: false,
+      explicitArrayExcludes: [],
       ignoreAttrs: false,
       mergeAttrs: false,
       explicitRoot: false,
@@ -281,16 +282,16 @@
     Parser.prototype.assignOrPush = function(obj, key, newValue) {
       if (!(key in obj)) {
         if (!this.options.explicitArray) {
-          if(this.options.explicitArrayExcludes.indexOf(key) === -1){
+          if(this.options.explicitArrayExcludes.indexOf(key) == -1){
               return obj[key] = newValue;
           }else{
               if (!(obj[key] instanceof Array)) {
-              obj[key] = [obj[key]];
-            }
+                obj[key] = [];
+              }
               return obj[key].push(newValue);
-            }
+          }
         } else {
-             return obj[key] = newValue;
+          return obj[key] = [newValue];
         }
       } else {
         if (!(obj[key] instanceof Array)) {

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -253,6 +253,18 @@ module.exports =
     equ r.sample.arraytest[0].item[1].subitem[0], 'Foo.'
     equ r.sample.arraytest[0].item[1].subitem[1], 'Bar.')
 
+  'test child node without explicitArrayExcludes': skeleton(explicitArray: false, explicitArrayExcludes: [], (r) ->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    equ r.sample.arraytest.item[0].subitem, 'Baz.'
+    equ r.sample.arraytest.item[1].subitem[0], 'Foo.'
+    equ r.sample.arraytest.item[1].subitem[1], 'Bar.')
+
+  'test child node with explicitArrayExcludes': skeleton(explicitArray: false, explicitArrayExcludes: [item], (r) ->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    equ r.sample.arraytest[0].item[0].subitem[0], 'Baz.'
+    equ r.sample.arraytest[0].item[1].subitem[0], 'Foo.'
+    equ r.sample.arraytest[0].item[1].subitem[1], 'Bar.')
+
   'test ignore attributes': skeleton(ignoreAttrs: true, (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10
     equ r.sample.chartest[0], 'Character data here!'

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -262,7 +262,8 @@ module.exports =
   'test child node with explicitArrayExcludes': skeleton(explicitArray: false, explicitArrayExcludes: ["item"], (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10
     equ r.sample.arraytest.item[0].subitem, 'Baz.'
-    equ r.sample.arraytest.item[1].subitem[0], 'Foo., 'Bar')
+    equ r.sample.arraytest.item[1].subitem[0], 'Foo.'
+    equ r.sample.arraytest.item[1].subitem[1], 'Bar.')
 
   'test ignore attributes': skeleton(ignoreAttrs: true, (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -262,8 +262,7 @@ module.exports =
   'test child node with explicitArrayExcludes': skeleton(explicitArray: false, explicitArrayExcludes: ["item"], (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10
     equ r.sample.arraytest.item[0].subitem, 'Baz.'
-    equ r.sample.arraytest.item[1].subitem, 'Foo.'
-    equ r.sample.arraytest.item[1].subitem, 'Bar.')
+    equ r.sample.arraytest.item[1].subitem[0], 'Foo., 'Bar')
 
   'test ignore attributes': skeleton(ignoreAttrs: true, (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -261,10 +261,9 @@ module.exports =
 
   'test child node with explicitArrayExcludes': skeleton(explicitArray: false, explicitArrayExcludes: ["item"], (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10
-    console.log(r.sample.arraytest[0]);
-    equ r.sample.arraytest[0].item[0].subitem[0], 'Baz.'
-    equ r.sample.arraytest[0].item[1].subitem[0], 'Foo.'
-    equ r.sample.arraytest[0].item[1].subitem[1], 'Bar.')
+    equ r.sample.arraytest.item[0].subitem, 'Baz.'
+    equ r.sample.arraytest.item[1].subitem, 'Foo.'
+    equ r.sample.arraytest.item[1].subitem, 'Bar.')
 
   'test ignore attributes': skeleton(ignoreAttrs: true, (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -261,6 +261,7 @@ module.exports =
 
   'test child node with explicitArrayExcludes': skeleton(explicitArray: false, explicitArrayExcludes: ["item"], (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10
+    console.log(r.sample.arraytest[0]);
     equ r.sample.arraytest[0].item[0].subitem[0], 'Baz.'
     equ r.sample.arraytest[0].item[1].subitem[0], 'Foo.'
     equ r.sample.arraytest[0].item[1].subitem[1], 'Bar.')

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -259,7 +259,7 @@ module.exports =
     equ r.sample.arraytest.item[1].subitem[0], 'Foo.'
     equ r.sample.arraytest.item[1].subitem[1], 'Bar.')
 
-  'test child node with explicitArrayExcludes': skeleton(explicitArray: false, explicitArrayExcludes: [item], (r) ->
+  'test child node with explicitArrayExcludes': skeleton(explicitArray: false, explicitArrayExcludes: ["item"], (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10
     equ r.sample.arraytest[0].item[0].subitem[0], 'Baz.'
     equ r.sample.arraytest[0].item[1].subitem[0], 'Foo.'


### PR DESCRIPTION
There is no ability to exclude tags from explicit array creation. Sometimes this can be helpful if you dont want to check if the property is an array or not.
E.g.:
InvolvedIds: 
[ { Id: '000011110100001010000100' },
{ Id: '000011110100001001000110' },
{ Id: '000011110100001010000101' } ]

InvolvedIds: 
[ { Id: '000011110100001010000100' }]

In you version it would look like this:
InvolvedIds: 
[ { Id: '000011110100001010000100' },
{ Id: '000011110100001001000110' },
{ Id: '000011110100001010000101' } ]

InvolvedIds: 
{ Id: '000011110100001010000100' }
