### PR TITLE
Add includeWhiteChars option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ value})``. Possible options are:
     0.4.9.
   * `charsAsChildren` (default `false`): Determines whether chars should be
     considered children if `explicitChildren` is on. Added in 0.2.5.
+  * `includeWhiteChars` (default `false`): Determines whether whitespace-only
+     text nodes should be included. Added in 0.4.17.
   * `async` (default `false`): Should the callbacks be async? This *might* be
     an incompatible change if your code depends on sync execution of callbacks.
     Future versions of `xml2js` might change this default, so the recommendation

--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -62,6 +62,7 @@
       explicitChildren: false,
       childkey: '@@',
       charsAsChildren: false,
+      includeWhiteChars: false,
       async: false,
       strict: true,
       attrNameProcessors: null,
@@ -87,6 +88,7 @@
       preserveChildrenOrder: false,
       childkey: '$$',
       charsAsChildren: false,
+      includeWhiteChars: false,
       async: false,
       strict: true,
       attrNameProcessors: null,
@@ -452,12 +454,15 @@
           s = stack[stack.length - 1];
           if (s) {
             s[charkey] += text;
-            if (_this.options.explicitChildren && _this.options.preserveChildrenOrder && _this.options.charsAsChildren && text.replace(/\\n/g, '').trim() !== '') {
+            if (_this.options.explicitChildren && _this.options.preserveChildrenOrder && _this.options.charsAsChildren && (_this.options.includeWhiteChars || text.replace(/\\n/g, '').trim() !== '')) {
               s[_this.options.childkey] = s[_this.options.childkey] || [];
               charChild = {
                 '#name': '__text__'
               };
               charChild[charkey] = text;
+              if (_this.options.normalize) {
+                charChild[charkey] = charChild[charkey].replace(/\s{2,}/g, " ").trim();
+              }
               s[_this.options.childkey].push(charChild);
             }
             return s;

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -378,7 +378,7 @@ class exports.Parser extends events.EventEmitter
       if s
         s[charkey] += text
 
-        if @options.explicitChildren and @options.preserveChildrenOrder and @options.charsAsChildren and (@options.includeWhiteChars || text.replace(/\\n/g, '').trim() isnt '')
+        if @options.explicitChildren and @options.preserveChildrenOrder and @options.charsAsChildren and (@options.includeWhiteChars or text.replace(/\\n/g, '').trim() isnt '')
           s[@options.childkey] = s[@options.childkey] or []
           charChild =
             '#name': '__text__'

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -59,6 +59,8 @@ exports.defaults =
     explicitChildren: false
     childkey: '@@'
     charsAsChildren: false
+    # include white-space only text nodes
+    includeWhiteChars: false
     # callbacks are async? not in 0.1 mode
     async: false
     strict: true
@@ -85,6 +87,8 @@ exports.defaults =
     preserveChildrenOrder: false
     childkey: '$$'
     charsAsChildren: false
+    # include white-space only text nodes
+    includeWhiteChars: false
     # not async in 0.2 mode either
     async: false
     strict: true
@@ -374,11 +378,12 @@ class exports.Parser extends events.EventEmitter
       if s
         s[charkey] += text
 
-        if @options.explicitChildren and @options.preserveChildrenOrder and @options.charsAsChildren and text.replace(/\\n/g, '').trim() isnt ''
+        if @options.explicitChildren and @options.preserveChildrenOrder and @options.charsAsChildren and (@options.includeWhiteChars || text.replace(/\\n/g, '').trim() isnt '')
           s[@options.childkey] = s[@options.childkey] or []
           charChild =
             '#name': '__text__'
           charChild[charkey] = text
+          charChild[charkey] = charChild[charkey].replace(/\s{2,}/g, " ").trim() if @options.normalize
           s[@options.childkey].push charChild
 
         s

--- a/test/fixtures/sample.xml
+++ b/test/fixtures/sample.xml
@@ -54,5 +54,5 @@
     <attrValueProcessTest camelCaseAttr="camelCaseAttrValue" lowerCaseAttr="lowercaseattrvalue" />
     <tagNameProcessTest/>
     <valueProcessTest>some value</valueProcessTest>
-    <textordertest>this is text with <b>markup</b> in the middle</textordertest>
+    <textordertest>this is text with <b>markup</b>   <em>like this</em> in the middle</textordertest>
 </sample>

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -183,8 +183,39 @@ module.exports =
     equ r.sample.$$[17].$$[0]._, 'this is text with '
     equ r.sample.$$[17].$$[1]['#name'], 'b'
     equ r.sample.$$[17].$$[1]._, 'markup'
-    equ r.sample.$$[17].$$[2]['#name'], '__text__'
-    equ r.sample.$$[17].$$[2]._, ' in the middle')
+    equ r.sample.$$[17].$$[2]['#name'], 'em'
+    equ r.sample.$$[17].$$[2]._, 'like this'
+    equ r.sample.$$[17].$$[3]['#name'], '__text__'
+    equ r.sample.$$[17].$$[3]._, ' in the middle')
+
+  'test parse with explicitChildren and charsAsChildren and preserveChildrenOrder and includeWhiteChars': skeleton(explicitChildren: true, preserveChildrenOrder: true, charsAsChildren: true, includeWhiteChars: true, (r) ->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    equ r.sample.$$[35]['#name'], 'textordertest'
+    equ r.sample.$$[35].$$[0]['#name'], '__text__'
+    equ r.sample.$$[35].$$[0]._, 'this is text with '
+    equ r.sample.$$[35].$$[1]['#name'], 'b'
+    equ r.sample.$$[35].$$[1]._, 'markup'
+    equ r.sample.$$[35].$$[2]['#name'], '__text__'
+    equ r.sample.$$[35].$$[2]._, '   '
+    equ r.sample.$$[35].$$[3]['#name'], 'em'
+    equ r.sample.$$[35].$$[3]._, 'like this'
+    equ r.sample.$$[35].$$[4]['#name'], '__text__'
+    equ r.sample.$$[35].$$[4]._, ' in the middle')
+
+  'test parse with explicitChildren and charsAsChildren and preserveChildrenOrder and includeWhiteChars and normalize': skeleton(explicitChildren: true, preserveChildrenOrder: true, charsAsChildren: true, includeWhiteChars: true, normalize: true, (r) ->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    # normalized whitespace-only text node becomes empty string
+    equ r.sample.$$[35]['#name'], 'textordertest'
+    equ r.sample.$$[35].$$[0]['#name'], '__text__'
+    equ r.sample.$$[35].$$[0]._, 'this is text with'
+    equ r.sample.$$[35].$$[1]['#name'], 'b'
+    equ r.sample.$$[35].$$[1]._, 'markup'
+    equ r.sample.$$[35].$$[2]['#name'], '__text__'
+    equ r.sample.$$[35].$$[2]._, ''
+    equ r.sample.$$[35].$$[3]['#name'], 'em'
+    equ r.sample.$$[35].$$[3]._, 'like this'
+    equ r.sample.$$[35].$$[4]['#name'], '__text__'
+    equ r.sample.$$[35].$$[4]._, 'in the middle')
 
   'test element without children': skeleton(explicitChildren: true, (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10


### PR DESCRIPTION
`includeWhiteChars` is useful for parsing HTML-like markup where
whitespace-only text nodes are significant. Consider
```
<p>some markup <b>like</b> <em>this</em></p>
```
Whith the `includeWhiteChars` option enabled, the output will contain
an extra text node with a space between the `b` and `em` elements.