### PR TITLE
Adding support for explicit children in builder

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -141,7 +141,7 @@
     }
 
     Builder.prototype.buildObject = function(rootObj) {
-      var attrkey, charkey, render, rootElement, rootName;
+      var attrkey, charkey, processKeyObject, render, rootElement, rootName;
       attrkey = this.options.attrkey;
       charkey = this.options.charkey;
       if ((Object.keys(rootObj).length === 1) && (this.options.rootName === exports.defaults['0.2'].rootName)) {
@@ -150,58 +150,75 @@
       } else {
         rootName = this.options.rootName;
       }
+      processKeyObject = (function(_this) {
+        return function(element, key, child) {
+          var attr, entry, index, results, results1, value;
+          if (key === attrkey) {
+            if (typeof child === "object") {
+              results = [];
+              for (attr in child) {
+                value = child[attr];
+                results.push(element = element.att(attr, value));
+              }
+              return results;
+            }
+          } else if (key === charkey) {
+            if (_this.options.cdata && requiresCDATA(child)) {
+              return element = element.raw(wrapCDATA(child));
+            } else {
+              return element = element.txt(child);
+            }
+          } else if (Array.isArray(child)) {
+            results1 = [];
+            for (index in child) {
+              if (!hasProp.call(child, index)) continue;
+              entry = child[index];
+              if (typeof entry === 'string') {
+                if (_this.options.cdata && requiresCDATA(entry)) {
+                  results1.push(element = element.ele(key).raw(wrapCDATA(entry)).up());
+                } else {
+                  results1.push(element = element.ele(key, entry).up());
+                }
+              } else {
+                results1.push(element = render(element.ele(key), entry).up());
+              }
+            }
+            return results1;
+          } else if (typeof child === "object") {
+            return element = render(element.ele(key), child).up();
+          } else {
+            if (typeof child === 'string' && _this.options.cdata && requiresCDATA(child)) {
+              return element = element.ele(key).raw(wrapCDATA(child)).up();
+            } else {
+              if (child == null) {
+                child = '';
+              }
+              return element = element.ele(key, child.toString()).up();
+            }
+          }
+        };
+      })(this);
       render = (function(_this) {
         return function(element, obj) {
-          var attr, child, entry, index, key, value;
+          var child, i, j, key, len, ref;
           if (typeof obj !== 'object') {
             if (_this.options.cdata && requiresCDATA(obj)) {
               element.raw(wrapCDATA(obj));
             } else {
               element.txt(obj);
             }
+          } else if (Array.isArray(obj["$$"])) {
+            element = processKeyObject(element, "$", obj["$"]);
+            ref = obj["$$"];
+            for (j = 0, len = ref.length; j < len; j++) {
+              i = ref[j];
+              element = processKeyObject(element, obj["$$"][i]["#name"], obj["$$"][i]);
+            }
           } else {
             for (key in obj) {
               if (!hasProp.call(obj, key)) continue;
               child = obj[key];
-              if (key === attrkey) {
-                if (typeof child === "object") {
-                  for (attr in child) {
-                    value = child[attr];
-                    element = element.att(attr, value);
-                  }
-                }
-              } else if (key === charkey) {
-                if (_this.options.cdata && requiresCDATA(child)) {
-                  element = element.raw(wrapCDATA(child));
-                } else {
-                  element = element.txt(child);
-                }
-              } else if (Array.isArray(child)) {
-                for (index in child) {
-                  if (!hasProp.call(child, index)) continue;
-                  entry = child[index];
-                  if (typeof entry === 'string') {
-                    if (_this.options.cdata && requiresCDATA(entry)) {
-                      element = element.ele(key).raw(wrapCDATA(entry)).up();
-                    } else {
-                      element = element.ele(key, entry).up();
-                    }
-                  } else {
-                    element = render(element.ele(key), entry).up();
-                  }
-                }
-              } else if (typeof child === "object") {
-                element = render(element.ele(key), child).up();
-              } else {
-                if (typeof child === 'string' && _this.options.cdata && requiresCDATA(child)) {
-                  element = element.ele(key).raw(wrapCDATA(child)).up();
-                } else {
-                  if (child == null) {
-                    child = '';
-                  }
-                  element = element.ele(key, child.toString()).up();
-                }
-              }
+              element = processKeyObject(element, key, child);
             }
           }
           return element;

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -128,6 +128,45 @@ class exports.Builder
       # otherwise we'll use whatever they've set, or the default
       rootName = @options.rootName
 
+    processKeyObject = (element, key, child) =>
+      # Case #1 Attribute
+      if key is attrkey
+        if typeof child is "object"
+          # Inserts tag attributes
+          for attr, value of child
+            element = element.att(attr, value)
+
+      # Case #2 Char data (CDATA, etc.)
+      else if key is charkey
+        if @options.cdata && requiresCDATA child
+          element = element.raw wrapCDATA child
+        else
+          element = element.txt child
+
+      # Case #3 Array data
+      else if Array.isArray child
+        for own index, entry of child
+          if typeof entry is 'string'
+            if @options.cdata && requiresCDATA entry
+              element = element.ele(key).raw(wrapCDATA entry).up()
+            else
+              element = element.ele(key, entry).up()
+          else
+            element = render(element.ele(key), entry).up()
+
+      # Case #4 Objects
+      else if typeof child is "object"
+        element = render(element.ele(key), child).up()
+
+      # Case #5 String and remaining types
+      else
+        if typeof child is 'string' && @options.cdata && requiresCDATA child
+          element = element.ele(key).raw(wrapCDATA child).up()
+        else
+          if not child?
+            child = ''
+          element = element.ele(key, child.toString()).up()
+
     render = (element, obj) =>
       if typeof obj isnt 'object'
         # single element, just append it as text
@@ -135,46 +174,13 @@ class exports.Builder
           element.raw wrapCDATA obj
         else
           element.txt obj
+      else if Array.isArray obj["$$"]
+        element = processKeyObject(element, "$", obj["$"])
+        for child in obj["$$"]
+          element = processKeyObject(element, child["#name"], child)
       else
         for own key, child of obj
-          # Case #1 Attribute
-          if key is attrkey
-            if typeof child is "object"
-              # Inserts tag attributes
-              for attr, value of child
-                element = element.att(attr, value)
-
-          # Case #2 Char data (CDATA, etc.)
-          else if key is charkey
-            if @options.cdata && requiresCDATA child
-              element = element.raw wrapCDATA child
-            else
-              element = element.txt child
-
-          # Case #3 Array data
-          else if Array.isArray child
-            for own index, entry of child
-              if typeof entry is 'string'
-                if @options.cdata && requiresCDATA entry
-                  element = element.ele(key).raw(wrapCDATA entry).up()
-                else
-                  element = element.ele(key, entry).up()
-              else
-                element = render(element.ele(key), entry).up()
-
-          # Case #4 Objects
-          else if typeof child is "object"
-            element = render(element.ele(key), child).up()
-
-          # Case #5 String and remaining types
-          else
-            if typeof child is 'string' && @options.cdata && requiresCDATA child
-              element = element.ele(key).raw(wrapCDATA child).up()
-            else
-              if not child?
-                child = ''
-              element = element.ele(key, child.toString()).up()
-
+          element = processKeyObject(element, key, child)
       element
 
     rootElement = builder.create(rootName, @options.xmldec, @options.doctype,


### PR DESCRIPTION
Before, when an xml was parsed with the options `preserveChildrenOrder` and `explicitChildren` set to true, the xml2js builder failed to rebuild the xml file from the javascript object. The xml2js builder has been extended now to support this use case.