### PR TITLE
Verify entry type in requiresCDATA function

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -32,7 +32,7 @@
   };
 
   requiresCDATA = function(entry) {
-    return entry.indexOf('&') >= 0 || entry.indexOf('>') >= 0 || entry.indexOf('<') >= 0;
+    return typeof entry === "string" && (entry.indexOf('&') >= 0 || entry.indexOf('>') >= 0 || entry.indexOf('<') >= 0);
   };
 
   wrapCDATA = function(entry) {

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -16,7 +16,7 @@ processName = (processors, processedName) ->
   return processedName
 
 requiresCDATA = (entry) ->
-  return entry.indexOf('&') >= 0 || entry.indexOf('>') >= 0 || entry.indexOf('<') >= 0
+  return typeof entry is "string" && (entry.indexOf('&') >= 0 || entry.indexOf('>') >= 0 || entry.indexOf('<') >= 0)
 
 # Note that we do this manually instead of using xmlbuilder's `.dat` method
 # since it does not support escaping the CDATA close entity (throws an error if

--- a/test/builder.test.coffee
+++ b/test/builder.test.coffee
@@ -249,3 +249,19 @@ module.exports =
     actual = builder.buildObject obj
     diffeq expected, actual
     test.finish()
+
+  'test does not error on array values when checking for cdata': (test) ->
+    expected = """
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <xml>
+        <MsgId>10</MsgId>
+        <MsgId>12</MsgId>
+      </xml>
+
+    """
+    opts = cdata: true
+    builder = new xml2js.Builder opts
+    obj = {"xml":{"MsgId":[10, 12]}}
+    actual = builder.buildObject obj
+    diffeq expected, actual
+    test.finish()


### PR DESCRIPTION
Verify entry type in requiresCDATA fn to avoid code breaking when trying to verify Numbers and Arrays.