### PR TITLE
Fix: Attributes are no longer arrays when mergeAttrs:true Fixes #304

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -341,7 +341,7 @@
               newValue = _this.options.attrValueProcessors ? processName(_this.options.attrValueProcessors, node.attributes[key]) : node.attributes[key];
               processedKey = _this.options.attrNameProcessors ? processName(_this.options.attrNameProcessors, key) : key;
               if (_this.options.mergeAttrs) {
-                _this.assignOrPush(obj, processedKey, newValue);
+                obj[processedKey] = newValue;
               } else {
                 obj[attrkey][processedKey] = newValue;
               }

--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -283,7 +283,7 @@ class exports.Parser extends events.EventEmitter
           newValue = if @options.attrValueProcessors then processName(@options.attrValueProcessors, node.attributes[key]) else node.attributes[key]
           processedKey = if @options.attrNameProcessors then processName(@options.attrNameProcessors, key) else key
           if @options.mergeAttrs
-            @assignOrPush obj, processedKey, newValue
+            obj[processedKey] = newValue
           else
             obj[attrkey][processedKey] = newValue
 


### PR DESCRIPTION
XML attributes can't be arrays. 

`explicitArray` makes only **`childNodes`** an array correctly.

When `mergeAttrs: true`, attributes should still not be an array but childNodes will respect `explicitArray` on whether they would be arrays or not.

This simple fix addresses that. @Leonidas-from-XIV looking forward to your response!
