### PR TITLE
Preserve Children Order in case of mixed content.

### DIFF
--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -105,6 +105,7 @@ exports.defaults =
     chunkSize: 10000
     emptyTag: ''
     cdata: false
+    preserveChildrenOrderForMixedContent:false
 
 class exports.ValidationError extends Error
   constructor: (message) ->
@@ -224,7 +225,11 @@ class exports.Parser extends events.EventEmitter
         @emit err
 
   assignOrPush: (obj, key, newValue) =>
-    if key not of obj
+    if @options.preserveChildrenOrderForMixedContent and obj.hasStrayText
+      tObj = {};
+      tObj[key] = newValue;
+      obj.content.push(tObj);
+    else if key not of obj
       if not @options.explicitArray
         obj[key] = newValue
       else
@@ -295,6 +300,11 @@ class exports.Parser extends events.EventEmitter
 
     @saxParser.onclosetag = =>
       obj = stack.pop()
+      if @options.preserveChildrenOrderForMixedContent and obj and obj.hasStrayText and obj.content
+        obj[@options.childkey] = obj.content
+        delete obj.content
+        delete obj.hasStrayText
+
       nodeName = obj["#name"]
       delete obj["#name"] if not @options.explicitChildren or not @options.preserveChildrenOrder
 
@@ -376,17 +386,69 @@ class exports.Parser extends events.EventEmitter
     ontext = (text) =>
       s = stack[stack.length - 1]
       if s
+        nodeName = s['#name']
+        if @options.preserveChildrenOrderForMixedContent
+          if s[charkey] and s[charkey].replace(/\\n\\t\\r/g, '').trim() != ''
+            s = wrap(s, text)
+            stack[stack.length - 1] = s
+            return s
+          else if s.hasStrayText
+            cloned = {}
+            txtObj = {}
+            txtObj[charkey] = text
+            keys = Object.keys(s)
+            if keys.length > 0
+              for k of keys
+                cloned[keys[k]] = s[keys[k]]
+              cloned.content.push txtObj
+            s = cloned
+            stack[stack.length - 1] = s
+            return s
+          else
+            keys = Object.keys(s)
+            hasStrayText = false
+            if keys.length > 0
+              for k of keys
+                if keys[k] != '$' and keys[k] != '#name' and (keys[k] != charkey or s[keys[k]] != "")
+                  hasStrayText = true
+                  break
+            if hasStrayText
+              s = wrap(s, text)
+              stack[stack.length - 1] = s
+              return s
         s[charkey] += text
-
-        if @options.explicitChildren and @options.preserveChildrenOrder and @options.charsAsChildren and (@options.includeWhiteChars or text.replace(/\\n/g, '').trim() isnt '')
+        if not @options.preserveChildrenOrderForMixedContent and (@options.explicitChildren and @options.preserveChildrenOrder and @options.charsAsChildren and (@options.includeWhiteChars or text.replace(/\\n/g, '').trim() != ''))
           s[@options.childkey] = s[@options.childkey] or []
-          charChild =
-            '#name': '__text__'
+          charChild = '#name': '__text__'
           charChild[charkey] = text
-          charChild[charkey] = charChild[charkey].replace(/\s{2,}/g, " ").trim() if @options.normalize
+          if @options.normalize
+            charChild[charkey] = charChild[charkey].replace(/\s{2,}/g, ' ').trim()
           s[@options.childkey].push charChild
+        return s
+      return
 
-        s
+    wrap = (s, text) =>
+      if text.replace(/\\n\\t\\r/g, '').trim() != ''
+        charkey = @options.charkey
+        keys = Object.keys(s)
+        if keys.length > 0
+          newObj =
+            hasStrayText: true
+            content: []
+          for k of keys
+            if keys[k] != '$' and keys[k] != '#name' and (keys[k] != charkey or s[keys[k]] != "")
+              nObj = {}
+              nObj[keys[k]] = s[keys[k]]
+              newObj.content.push nObj
+          txtObj = {}
+          txtObj[charkey] = text
+          newObj.content.push txtObj
+          newObj['#name'] = s['#name']
+          if s['$']
+            newObj['$'] = s['$']
+          newObj[charkey] = "";
+          return newObj
+      s
 
     @saxParser.ontext = ontext
     @saxParser.oncdata = (text) =>


### PR DESCRIPTION
In current functionality, in order to maintain Chilren Order in case if mixed content like this:

<TailParas fid="td">
	<Para>That capitulation reflects the conundrum facing Mr. Ballmer's successor, <En cat="pe" fpRef="958861" instRef="7" djRef="9589153">Satya Nadella</En>, who took over two years ago, as he runs out of options to bolster <En cat="co" fpRef="27147355" instRef="8" djRef="mcrost">Microsoft</En>'s standing in mobile technology. His new strategy aims to help information-technology managers cope with the increasingly central position of smartphones in corporate networks. The company is betting that corporate customers will want to use <En cat="co" fpRef="27147355" instRef="9" djRef="mcrost">Microsoft</En>'s technology to lock down and control devices on their networks.</Para>
	<Para>In a statement, Mr. Nadella also touted its Continuum feature, which enables a smartphone running Windows 10 to function as a surrogate PC when connected to a monitor and keyboard.</Para>
	<Para>
		<En cat="co" fpRef="27147355" instRef="10" djRef="mcrost">Microsoft</En> must establish its Windows operating system on a substantial portion of smartphones or accept a diminished presence in the technology landscape, where mobile devices outnumber personal computers—and it may not get another chance, said Forrester Research Inc. analyst Julie Ask.</Para>
</TailParas>

you need to pass these flags: 
explicitChildren: true, preserveChildrenOrder : true, charsAsChildren: true, includeWhiteChars: true
And these flag generates lots of extraneous json nodes.

With this change I have added a flag called preserveChildrenOrderForMixedContent (default is false). But if it's turned on, it will generate following output. Basically, it's smart enough to detect that it has mixed content and will wrap the object only if required in order to maintain the order.

{
  "$": {
    "fid": "td"
  },
  "Para": [
    {
      "$$": [
        {
          "_": "That capitulation reflects the conundrum facing Mr. Ballmer\'s successor, "
        },
        {
          "En": {
            "_": "Satya Nadella",
            "$": {
              "cat": "pe",
              "fpRef": "958861",
              "instRef": "7",
              "djRef": "9589153"
            }
          }
        },
        {
          "_": ", who took over two years ago, as he runs out of options to bolster "
        },
        {
          "En": {
            "_": "Microsoft",
            "$": {
              "cat": "co",
              "fpRef": "27147355",
              "instRef": "8",
              "djRef": "mcrost"
            }
          }
        },
        {
          "_": "\'s standing in mobile technology. His new strategy aims to help information-technology managers cope with the increasingly central position of smartphones in corporate networks. The company is betting that corporate customers will want to use "
        },
        {
          "En": {
            "_": "Microsoft",
            "$": {
              "cat": "co",
              "fpRef": "27147355",
              "instRef": "9",
              "djRef": "mcrost"
            }
          }
        },
        {
          "_": "\'s technology to lock down and control devices on their networks."
        }
      ]
    },
    "In a statement, Mr. Nadella also touted its Continuum feature, which enables a smartphone running Windows 10 to function as a surrogate PC when connected to a monitor and keyboard.",
    {
      "$$": [
        {
          "_": "\\n            "
        },
        {
          "En": {
            "_": "Microsoft",
            "$": {
              "cat": "co",
              "fpRef": "27147355",
              "instRef": "10",
              "djRef": "mcrost"
            }
          }
        },
        {
          "_": " must establish its Windows operating system on a substantial portion of smartphones or accept a diminished presence in the technology landscape, where mobile devices outnumber personal computers—and it may not get another chance, said Forrester Research Inc. analyst Julie Ask."
        }
      ]
    }
  ]
}