### PR TITLE
Improved support for doctype

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -207,10 +207,15 @@
           return element;
         };
       })(this);
-      rootElement = builder.create(rootName, this.options.xmldec, this.options.doctype, {
+      rootElement = builder.create(rootName, this.options.xmldec, {
         headless: this.options.headless,
         allowSurrogateChars: this.options.allowSurrogateChars
       });
+      if(this.options.doctype !== null){
+         // Add doctype at root level
+        rootElement = rootElement.dtd( this.options.doctype).up();
+      }
+     
       return render(rootElement, rootObj).end(this.options.renderOpts);
     };
 


### PR DESCRIPTION
When generating XML from JSON the optional field _doctype_ receives an string value.

Ex: {..., doctype: 'TEST.DTD'}
