### PR TITLE
Unnecessary statement setImmediate require

### DIFF
--- a/lib/xml2js.js
+++ b/lib/xml2js.js
@@ -16,8 +16,6 @@
 
   processors = require('./processors');
 
-  setImmediate = require('timers').setImmediate;
-
   isEmpty = function(thing) {
     return typeof thing === "object" && (thing != null) && Object.keys(thing).length === 0;
   };


### PR DESCRIPTION
While doing a react-native project I realized that will not compile because it was requiring a native module, which is `timers`. Maybe I am wrong but these are suppose to be global variables and thus, that statement is unnecessary and reduces compatibility across platforms.

Moreover `sax` uses native `streams` modules, so it requires a little further transformation to be 100% compatible.

Thanks for your work :)