### PR TITLE
Improves compatibility removing unnecesary require of `setImmediate`

### DIFF
--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -5,7 +5,6 @@ events = require 'events'
 builder = require 'xmlbuilder'
 bom = require './bom'
 processors = require './processors'
-setImmediate = require('timers').setImmediate
 
 # Underscore has a nice function for this, but we try to go without dependencies
 isEmpty = (thing) ->


### PR DESCRIPTION
While doing a react-native project I realized that will not compile because it was requiring a native module, which is timers. Maybe I am wrong but these are suppose to be global variables and thus, that statement is unnecessary and reduces compatibility across platforms.

Moreover sax uses native streams modules, so it requires a little further transformation to be 100% compatible.

Thanks for your work :)
