### PR TITLE
Preserve fidelity of numbers when parsing them

### DIFF
--- a/src/processors.coffee
+++ b/src/processors.coffee
@@ -14,7 +14,14 @@ exports.stripPrefix = (str) ->
 
 exports.parseNumbers = (str) ->
   if !isNaN str
-    str = if str % 1 == 0 then parseInt str, 10 else parseFloat str
+    num = if str % 1 == 0 then parseInt str, 10 else parseFloat str
+
+    isTooLarge = num >= Number.MAX_SAFE_INTEGER
+    # If number is too large for accurate representation, preserve the stringified version
+    if !isTooLarge 
+      return num
+    return str
+
   return str
 
 exports.parseBooleans = (str) ->

--- a/test/processors.test.coffee
+++ b/test/processors.test.coffee
@@ -38,6 +38,7 @@ module.exports =
     equ processors.parseNumbers('123'), 123
     equ processors.parseNumbers('15.56'), 15.56
     equ processors.parseNumbers('10.00'), 10
+    equ processors.parseNumbers('1111111111111111111111111') '1111111111111111111111111'
     test.done()
 
   'test parseBooleans': (test) ->


### PR DESCRIPTION
This is a very small and simple change to preserve fidelity when parsing large numbers.

When parsing numbers, `parseInt` and `parseFloat` tend to round down large numbers (where large means greater than [`Number.MAX_SAFE_INTEGER` ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER)). This causes rounding issues when parsing financial data. In these cases, it may actually be better to just return the original string representation instead.

The reason why this makes sense as default behavior, instead of a custom parser, is to allow fo interoperability and ease of transformation between the JS and the XML without losing fidelity. I'm also open to suggested changes (removing all non-numeric characters, making this an optional switch or a separate parser, etc,) but wanted to put this up for discussion.