### PR TITLE
fix browserify and zurvan support for async parsing

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -4,7 +4,7 @@ sax = require 'sax'
 events = require 'events'
 bom = require './bom'
 processors = require './processors'
-setImmediate = require('timers').setImmediate
+global.setImmediate = require('timers').setImmediate
 defaults = require('./defaults').defaults
 
 # Underscore has a nice function for this, but we try to go without dependencies


### PR DESCRIPTION
It looks like the change from https://github.com/Leonidas-from-XIV/node-xml2js/commit/7ad0051830e073adce7e1f66996951ada2d70053 was lost when parser was moved to own file https://github.com/Leonidas-from-XIV/node-xml2js/commit/57dca2f7fcf359d6505ce94d98921335935e83e7