### PR TITLE
Feature/tag name processors with path

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,19 @@ parseString(xml, {
 });
 ```
 
-The `tagNameProcessors` and `attrNameProcessors` options
-accept an `Array` of functions with the following signature:
+The `tagNameProcessors` option accept an `Array` 
+of functions with the following signature:
+
+```javascript
+function (name, path){
+  //do something with `name`
+  //path is array of nodo names e.g. ['parentName'] 
+  return name
+}
+```
+
+The `attrNameProcessors` option accept an `Array` 
+of functions with the following signature:
 
 ```javascript
 function (name){

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ parseString(xml, {
 });
 ```
 
-The `tagNameProcessors` option accept an `Array` 
+The `tagNameProcessors` option accepts an `Array` 
 of functions with the following signature:
 
 ```javascript
@@ -193,7 +193,7 @@ function (name, path){
 }
 ```
 
-The `attrNameProcessors` option accept an `Array` 
+The `attrNameProcessors` option accepts an `Array` 
 of functions with the following signature:
 
 ```javascript


### PR DESCRIPTION
I added a path param resulting in the new signature for tagNameProcessors(name, path)

We needed this to process node names based on their actual path, e.g. 

```
const options = {
      trim: true,
      explicitArray: false,
      ignoreAttrs: false,
      tagNameProcessors: [function (childName, pathArray) {
        pathArray.push(childName);
        const pathWithChildInDotNotation = pathArray.join('.');
        return pathWithChildInDotNotation;
      }],
    };
```
I am looking forward to your comments!
Matthias