### PR TITLE
Fix issue #119.

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -56,6 +56,15 @@
             } else {
               element.txt(obj);
             }
+          } else if (Array.isArray(obj)) {
+            for (index in obj) {
+              if (!hasProp.call(obj, index)) continue;
+              child = obj[index];
+              for (key in child) {
+                entry = child[key];
+                element = render(element.ele(key), entry).up();
+              }
+            }
           } else {
             for (key in obj) {
               if (!hasProp.call(obj, key)) continue;

--- a/src/builder.coffee
+++ b/src/builder.coffee
@@ -48,6 +48,11 @@ class exports.Builder
           element.raw wrapCDATA obj
         else
           element.txt obj
+      else if Array.isArray obj
+        # fix issue #119
+        for own index, child of obj
+          for key, entry of child
+            element = render(element.ele(key), entry).up()
       else
         for own key, child of obj
           # Case #1 Attribute

--- a/test/builder.test.coffee
+++ b/test/builder.test.coffee
@@ -265,3 +265,19 @@ module.exports =
     actual = builder.buildObject obj
     diffeq expected, actual
     test.finish()
+
+  'test building obj with array': (test) ->
+    expected = """
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <root>
+        <MsgId>10</MsgId>
+        <MsgId2>12</MsgId2>
+      </root>
+
+    """
+    opts = cdata: true
+    builder = new xml2js.Builder opts
+    obj = [{"MsgId": 10}, {"MsgId2": 12}]
+    actual = builder.buildObject obj
+    diffeq expected, actual
+    test.finish()


### PR DESCRIPTION
Now, if try
```
builder.buildObject([{"a": 1}, {"b": 2}])
```
will get the result:
```
<root>
  <a>1</a>
  <b>2</b>
</root>
```