### PR TITLE
Add forceCdata option to builder to force the use of CDATA tags for all content.

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,8 @@ Possible options are:
   * `cdata` (default: `false`): wrap text nodes in `<![CDATA[ ... ]]>` instead of
     escaping when necessary. Does not add `<![CDATA[ ... ]]>` if it is not required.
     Added in 0.4.5.
+  * `forceCdata` (default: `false`): always wrap text nodes in `<![CDATA[ ... ]]>`,
+    even if not required.
 
 `renderOpts`, `xmldec`,`doctype` and `headless` pass through to
 [xmlbuilder-js](https://github.com/oozcitak/xmlbuilder-js).

--- a/src/builder.coffee
+++ b/src/builder.coffee
@@ -44,7 +44,7 @@ class exports.Builder
     render = (element, obj) =>
       if typeof obj isnt 'object'
         # single element, just append it as text
-        if @options.cdata && requiresCDATA obj
+        if @options.forceCdata || (@options.cdata && requiresCDATA obj)
           element.raw wrapCDATA obj
         else
           element.txt obj
@@ -64,7 +64,7 @@ class exports.Builder
 
           # Case #2 Char data (CDATA, etc.)
           else if key is charkey
-            if @options.cdata && requiresCDATA child
+            if @options.forceCdata || (@options.cdata && requiresCDATA child)
               element = element.raw wrapCDATA child
             else
               element = element.txt child
@@ -73,7 +73,7 @@ class exports.Builder
           else if Array.isArray child
             for own index, entry of child
               if typeof entry is 'string'
-                if @options.cdata && requiresCDATA entry
+                if @options.forceCdata || (@options.cdata && requiresCDATA entry)
                   element = element.ele(key).raw(wrapCDATA entry).up()
                 else
                   element = element.ele(key, entry).up()
@@ -86,7 +86,7 @@ class exports.Builder
 
           # Case #5 String and remaining types
           else
-            if typeof child is 'string' && @options.cdata && requiresCDATA child
+            if typeof child is 'string' && (@options.forceCdata || (@options.cdata && requiresCDATA child))
               element = element.ele(key).raw(wrapCDATA child).up()
             else
               if not child?

--- a/src/defaults.coffee
+++ b/src/defaults.coffee
@@ -70,4 +70,5 @@ exports.defaults = {
     chunkSize: 10000
     emptyTag: ''
     cdata: false
+    forceCdata: false
 }

--- a/test/builder.test.coffee
+++ b/test/builder.test.coffee
@@ -281,3 +281,18 @@ module.exports =
     actual = builder.buildObject obj
     diffeq expected, actual
     test.finish()
+
+  'test always uses cdata for string values with forceCdata enabled': (test) ->
+    expected = """
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <xml>
+        <MsgId><![CDATA[hello world]]></MsgId>
+      </xml>
+
+    """
+    opts = forceCdata: true
+    builder = new xml2js.Builder opts
+    obj = {"xml":{"MsgId":"hello world"}}
+    actual = builder.buildObject obj
+    diffeq expected, actual
+    test.finish()


### PR DESCRIPTION
This PR adds a `forceCdata` option to the XML builder that wraps all text nodes in CDATA even when it is not required. This option is set to `false` by default. A new test exercises the `forceCdata` option using a small sample of text that does not require escaping.