### PR TITLE
Update is_empty to validate date

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -9,7 +9,7 @@ defaults = require('./defaults').defaults
 
 # Underscore has a nice function for this, but we try to go without dependencies
 isEmpty = (thing) ->
-  return typeof thing is "object" && thing? && Object.keys(thing).length is 0
+  return typeof thing is Object && !thing && Object.keys(thing).length is 0
 
 processItem = (processors, item, key) ->
   item = process(item, key) for process in processors


### PR DESCRIPTION
Because of new ES6 syntax `typeof thing is Object` is not the same as `typeof thing is 'Object'` and the first one seem to work with a wider variety of object