### PR TITLE
Patch 3

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -19,7 +19,7 @@
   defaults = require('./defaults').defaults;
 
   isEmpty = function(thing) {
-    return typeof thing === "object" && (thing != null) && Object.keys(thing).length === 0;
+    return typeof thing === Object && (thing != null) && Object.keys(thing).length === 0;
   };
 
   processItem = function(processors, item, key) {

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -9,7 +9,7 @@ defaults = require('./defaults').defaults
 
 # Underscore has a nice function for this, but we try to go without dependencies
 isEmpty = (thing) ->
-  return typeof thing is "object" && thing? && Object.keys(thing).length is 0
+  return typeof thing is Object && thing? && Object.keys(thing).length is 0
 
 processItem = (processors, item, key) ->
   item = process(item, key) for process in processors


### PR DESCRIPTION
Because of new ES6 syntax typeof thing is Object is not the same as typeof thing is 'Object' and the first one seem to work with a wider variety of object

