### PR TITLE
Add the sourcemap option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,59 @@ value})``. Possible options are:
     }
     ```
     Added in 0.4.6
+  * `sourcemap` (default: `false`): Allows exporting node positions in the XML
+    source document. By default it adds to all nodes a non-enumerable property
+    called `$source` (doesn't show up during enumeration of the properties on the objects).
+    The name of the property and whether or not you want it enumerable can be
+    configured with the options below.
+  * `sourcemapkey` (default: `$source`): Change the key to use when exporting sourcemaps.
+  * `sourcemapEnumerable` (default: `false`): Make the sourcemap enumerable (visible).
+    Note that converting back the JSON to XML will include `$source` attributes
+    if you make them enumerable. Here's a small example:
+    ```javascript
+      xml = "<a>\n  <b>hello</b>\n</a>";
+      xml2js.parseString(xml, {sourcemap: true, sourcemapEnumerable: true}, (err, parsed) => {
+        console.log(JSON.stringify(parsed));
+      });
+    ```
+    This will output:
+    ```json
+    {
+      "a": {
+        "$source": {
+          "start": {
+            "line": 0,
+            "column": 3,
+            "position": 3
+          },
+          "end": {
+            "line": 2,
+            "column": 4,
+            "position": 23
+          }
+        },
+        "b": [
+          {
+            "_": "hello",
+            "$source": {
+              "start": {
+                "line": 1,
+                "column": 5,
+                "position": 9
+              },
+              "end": {
+                "line": 1,
+                "column": 14,
+                "position": 18
+              }
+            }
+          }
+        ]
+      }
+    }
+    ```
+    If `sourcemapEnumerable` was not set, `$source` wouldn't appear in the generated
+    JSON but would be accessible the same way.
 
 Options for the `Builder` class
 -------------------------------

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -65,7 +65,10 @@
       headless: false,
       chunkSize: 10000,
       emptyTag: '',
-      cdata: false
+      cdata: false,
+      sourcemap: false,
+      sourcemapkey: '$source',
+      sourcemapEnumerable: false
     }
   };
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -37,6 +37,9 @@
     function Parser(opts) {
       this.parseString = bind(this.parseString, this);
       this.reset = bind(this.reset, this);
+      this.setNonEnumerableSourcemap = bind(this.setNonEnumerableSourcemap, this);
+      this.storeSourcemapEnd = bind(this.storeSourcemapEnd, this);
+      this.storeSourcemapStart = bind(this.storeSourcemapStart, this);
       this.assignOrPush = bind(this.assignOrPush, this);
       this.processAsync = bind(this.processAsync, this);
       var key, ref, value;
@@ -105,6 +108,56 @@
       }
     };
 
+    Parser.prototype.storeSourcemapStart = function(obj, value) {
+      if (this.options.sourcemap) {
+        return Object.defineProperty(obj, this.options.sourcemapkey, {
+          value: {
+            start: {
+              line: value.line,
+              column: value.column,
+              position: value.position
+            }
+          },
+          enumerable: true,
+          configurable: true
+        });
+      }
+    };
+
+    Parser.prototype.storeSourcemapEnd = function(obj, value) {
+      var currentValue;
+      if (this.options.sourcemap) {
+        currentValue = obj[this.options.sourcemapkey];
+        return Object.defineProperty(obj, this.options.sourcemapkey, {
+          value: {
+            start: currentValue.start,
+            end: {
+              line: value.line,
+              column: value.column,
+              position: value.position
+            }
+          }
+        });
+      }
+    };
+
+    Parser.prototype.setNonEnumerableSourcemap = function(obj) {
+      var key, results;
+      if (obj instanceof Object) {
+        if (this.options.sourcemapkey in obj) {
+          Object.defineProperty(obj, this.options.sourcemapkey, {
+            enumerable: false
+          });
+        }
+        results = [];
+        for (key in obj) {
+          if (!hasProp.call(obj, key)) continue;
+          results.push(this.setNonEnumerableSourcemap(obj[key]));
+        }
+        return results;
+      }
+    };
+
     Parser.prototype.reset = function() {
       var attrkey, charkey, ontext, stack;
       this.removeAllListeners();
@@ -142,6 +195,7 @@
           var key, newValue, obj, processedKey, ref;
           obj = {};
           obj[charkey] = "";
+          _this.storeSourcemapStart(obj, _this.saxParser);
           if (!_this.options.ignoreAttrs) {
             ref = node.attributes;
             for (key in ref) {
@@ -176,6 +230,7 @@
           if (!_this.options.explicitChildren || !_this.options.preserveChildrenOrder) {
             delete obj["#name"];
           }
+          _this.storeSourcemapEnd(obj, _this.saxParser);
           if (obj.cdata === true) {
             cdata = obj.cdata;
             delete obj.cdata;
@@ -257,6 +312,9 @@
               obj[nodeName] = old;
             }
             _this.resultObject = obj;
+            if (_this.options.sourcemap && !_this.options.sourcemapEnumerable) {
+              _this.setNonEnumerableSourcemap(_this.resultObject);
+            }
             _this.saxParser.ended = true;
             return _this.emit("end", _this.resultObject);
           }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "David Wood <david.p.wood@gmail.com> (http://codesleuth.co.uk/)",
     "Nicolas Maquet (https://github.com/nmaquet)",
     "Lovell Fuller (http://lovell.info/)",
+    "Jean-Christophe Hoelt (http://github.com/j3k0)",
     "d3adc0d3 (https://github.com/d3adc0d3)"
   ],
   "main": "./lib/xml2js",

--- a/src/defaults.coffee
+++ b/src/defaults.coffee
@@ -70,4 +70,7 @@ exports.defaults = {
     chunkSize: 10000
     emptyTag: ''
     cdata: false
+    sourcemap: false
+    sourcemapkey: '$source'
+    sourcemapEnumerable: false
 }

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -574,3 +574,32 @@ module.exports =
     console.log 'Result object: ' + util.inspect r, false, 10
     equ r.hasOwnProperty('SAMP'), true
     equ r.SAMP.hasOwnProperty('TAGN'), true)
+
+  'test source map with defaults': (test) ->
+    xml = "<a>\n  <b>hello</b>\n  <c><d/></c>\n</a>"
+    xml2js.parseString xml, {sourcemap: true}, (err, parsed) ->
+      # sourcemap doesn't appear, but can be accessed anyway
+      equ JSON.stringify(parsed).indexOf("$source") < 0, true
+      equ parsed.a.$source.start.line, 0
+      equ parsed.a.$source.end.line, 3
+      equ parsed.a.b[0].$source.start.line, 1
+      equ parsed.a.b[0].$source.end.line, 1
+      equ parsed.a.c[0].$source.start.line, 2
+      equ parsed.a.c[0].$source.end.line, 2
+      equ parsed.a.c[0].d[0].$source.start.line, 2
+      test.finish()
+
+  'test source map with sourcemapEnumerable': (test) ->
+    xml = "<a>\n  <b>hello</b>\n  <c><d/></c>\n</a>"
+    xml2js.parseString xml, {sourcemap: true, sourcemapEnumerable: true}, (err, parsed) ->
+      # sourcemap is public
+      equ JSON.stringify(parsed).indexOf("$source") > 0, true
+      equ parsed.a.$source.start.line, 0
+      equ parsed.a.$source.end.line, 3
+      equ parsed.a.b[0].$source.start.line, 1
+      equ parsed.a.b[0].$source.end.line, 1
+      equ parsed.a.c[0].$source.start.line, 2
+      equ parsed.a.c[0].$source.end.line, 2
+      equ parsed.a.c[0].d[0].$source.start.line, 2
+      test.finish()
+


### PR DESCRIPTION
This adds, for each node, the line, column and position of the `start` and `end` of the block in the source XML file.

Ref #139 - See README's diff for full details.

A quick note on a design choice which might be worth thinking through.

By defaults this adds a `$source` property to all nodes as a non-enumerable property, it means that this attribute is readable but doesn't affect anyone not using it. `sourcemap` could default to `true`: disabling it is just a matter of a minor performance improvement and lower memory usage.

BTW, I could have setup the pattern in a more generalized way: move this to a `$metadata` non-enumerable property that can potentially be used for different features (like storing the node name -- currently in `#name`). Then have an option to expose `$metadata` as a enumerable property (basically rename the `sourcemapkey` and `sourcemapEnumerable` to `metadatakey` and `metadataEnumerable`). This could be more future-proof, but let me know what you think first!