### PR TITLE
Add support for 'always' cdata builder option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
+.idea
 node_modules
 npm-debug.log
 .nyc_output

--- a/README.md
+++ b/README.md
@@ -347,9 +347,10 @@ Possible options are:
   * `headless` (default: `false`): omit the XML header. Added in 0.4.3.
   * `allowSurrogateChars` (default: `false`): allows using characters from the Unicode
     surrogate blocks.
-  * `cdata` (default: `false`): wrap text nodes in `<![CDATA[ ... ]]>` instead of
-    escaping when necessary. Does not add `<![CDATA[ ... ]]>` if it is not required.
+  * `cdata` (default: `false`): 
+    *  When `true` wrap text nodes in `<![CDATA[ ... ]]>` instead of escaping when necessary. Does not add `<![CDATA[ ... ]]>` if it is not required.
     Added in 0.4.5.
+    * When `'always'` all inner text wrapped in `<![CDATA[ ... ]]>` regardless of content.
 
 `renderOpts`, `xmldec`,`doctype` and `headless` pass through to
 [xmlbuilder-js](https://github.com/oozcitak/xmlbuilder-js).

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -51,7 +51,7 @@
         return function(element, obj) {
           var attr, child, entry, index, key, value;
           if (typeof obj !== 'object') {
-            if (_this.options.cdata && requiresCDATA(obj)) {
+            if (_this.options.cdata === 'always' || (_this.options.cdata && requiresCDATA(obj))) {
               element.raw(wrapCDATA(obj));
             } else {
               element.txt(obj);
@@ -77,7 +77,7 @@
                   }
                 }
               } else if (key === charkey) {
-                if (_this.options.cdata && requiresCDATA(child)) {
+                if (_this.options.cdata === 'always' || (_this.options.cdata && requiresCDATA(child))) {
                   element = element.raw(wrapCDATA(child));
                 } else {
                   element = element.txt(child);
@@ -87,7 +87,7 @@
                   if (!hasProp.call(child, index)) continue;
                   entry = child[index];
                   if (typeof entry === 'string') {
-                    if (_this.options.cdata && requiresCDATA(entry)) {
+                    if (_this.options.cdata === 'always' || (_this.options.cdata && requiresCDATA(entry))) {
                       element = element.ele(key).raw(wrapCDATA(entry)).up();
                     } else {
                       element = element.ele(key, entry).up();
@@ -99,7 +99,7 @@
               } else if (typeof child === "object") {
                 element = render(element.ele(key), child).up();
               } else {
-                if (typeof child === 'string' && _this.options.cdata && requiresCDATA(child)) {
+                if (typeof child === 'string' && _this.options.cdata === 'always' || (_this.options.cdata && requiresCDATA(child))) {
                   element = element.ele(key).raw(wrapCDATA(child)).up();
                 } else {
                   if (child == null) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -176,7 +176,7 @@
           if (!_this.options.explicitChildren || !_this.options.preserveChildrenOrder) {
             delete obj["#name"];
           }
-          if (obj.cdata === true) {
+          if (obj.cdata === 'always' || obj.cdata === true) {
             cdata = obj.cdata;
             delete obj.cdata;
           }

--- a/src/builder.coffee
+++ b/src/builder.coffee
@@ -44,7 +44,7 @@ class exports.Builder
     render = (element, obj) =>
       if typeof obj isnt 'object'
         # single element, just append it as text
-        if @options.cdata && requiresCDATA obj
+        if @options.cdata is 'always' or (@options.cdata && requiresCDATA obj)
           element.raw wrapCDATA obj
         else
           element.txt obj
@@ -64,7 +64,7 @@ class exports.Builder
 
           # Case #2 Char data (CDATA, etc.)
           else if key is charkey
-            if @options.cdata && requiresCDATA child
+            if @options.cdata is 'always' or (@options.cdata && requiresCDATA child)
               element = element.raw wrapCDATA child
             else
               element = element.txt child
@@ -73,7 +73,7 @@ class exports.Builder
           else if Array.isArray child
             for own index, entry of child
               if typeof entry is 'string'
-                if @options.cdata && requiresCDATA entry
+                if @options.cdata is 'always' or (@options.cdata && requiresCDATA entry)
                   element = element.ele(key).raw(wrapCDATA entry).up()
                 else
                   element = element.ele(key, entry).up()
@@ -86,7 +86,7 @@ class exports.Builder
 
           # Case #5 String and remaining types
           else
-            if typeof child is 'string' && @options.cdata && requiresCDATA child
+            if typeof child is 'string' && @options.cdata is 'always' or (@options.cdata && requiresCDATA child)
               element = element.ele(key).raw(wrapCDATA child).up()
             else
               if not child?

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -126,7 +126,7 @@ class exports.Parser extends events.EventEmitter
       nodeName = obj["#name"]
       delete obj["#name"] if not @options.explicitChildren or not @options.preserveChildrenOrder
 
-      if obj.cdata == true
+      if obj.cdata is 'always' or obj.cdata == true
         cdata = obj.cdata
         delete obj.cdata
 

--- a/test/builder.test.coffee
+++ b/test/builder.test.coffee
@@ -220,6 +220,22 @@ module.exports =
     diffeq expected, actual
     test.finish()
 
+  "test uses cdata for all chars when cdata is 'always'": (test) ->
+    expected = """
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <xml>
+        <MsgId><![CDATA[& <<]]></MsgId>
+        <Message><![CDATA[Hello]]></Message>
+      </xml>
+
+    """
+    opts = cdata: 'always'
+    builder = new xml2js.Builder opts
+    obj = {"xml":{"MsgId":["& <<"],"Message":["Hello"]}}
+    actual = builder.buildObject obj
+    diffeq expected, actual
+    test.finish()
+
   'test uses cdata for string values of objects': (test) ->
     expected = """
       <?xml version="1.0" encoding="UTF-8" standalone="yes"?>


### PR DESCRIPTION
Not sure if this is something you want, but I had to add it as a workaround for a legacy service I'm working with that wouldn't handle strings not escaped with CDATA.