### PR TITLE
Pass stringify option through to xmlbuilder-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,13 +345,17 @@ Possible options are:
     * `xmldec.standalone` standalone document declaration: true or false
   * `doctype` (default `null`): optional DTD. Eg. `{'ext': 'hello.dtd'}`
   * `headless` (default: `false`): omit the XML header. Added in 0.4.3.
+  * `stringify` (default: `null`): a set of functions to use for converting values to strings
+    (see `xmlbuilder-js`'s
+    [XMLStringifier](https://github.com/oozcitak/xmlbuilder-js/blob/master/src/XMLStringifier.coffee)
+    class for more information)
   * `allowSurrogateChars` (default: `false`): allows using characters from the Unicode
     surrogate blocks.
   * `cdata` (default: `false`): wrap text nodes in `<![CDATA[ ... ]]>` instead of
     escaping when necessary. Does not add `<![CDATA[ ... ]]>` if it is not required.
     Added in 0.4.5.
 
-`renderOpts`, `xmldec`,`doctype` and `headless` pass through to
+`renderOpts`, `xmldec`,`doctype`, `stringify`, and `headless` pass through to
 [xmlbuilder-js](https://github.com/oozcitak/xmlbuilder-js).
 
 Updating to new version

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -115,6 +115,7 @@
       })(this);
       rootElement = builder.create(rootName, this.options.xmldec, this.options.doctype, {
         headless: this.options.headless,
+        stringify: this.options.stringify,
         allowSurrogateChars: this.options.allowSurrogateChars
       });
       return render(rootElement, rootObj).end(this.options.renderOpts);

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -62,6 +62,7 @@
         'indent': '  ',
         'newline': '\n'
       },
+      stringify: null,
       headless: false,
       chunkSize: 10000,
       emptyTag: '',

--- a/src/builder.coffee
+++ b/src/builder.coffee
@@ -97,6 +97,7 @@ class exports.Builder
 
     rootElement = builder.create(rootName, @options.xmldec, @options.doctype,
       headless: @options.headless
+      stringify: @options.stringify
       allowSurrogateChars: @options.allowSurrogateChars)
 
     render(rootElement, rootObj).end(@options.renderOpts)

--- a/src/defaults.coffee
+++ b/src/defaults.coffee
@@ -66,6 +66,7 @@ exports.defaults = {
     xmldec: {'version': '1.0', 'encoding': 'UTF-8', 'standalone': true}
     doctype: null
     renderOpts: { 'pretty': true, 'indent': '  ', 'newline': '\n' }
+    stringify: null
     headless: false
     chunkSize: 10000
     emptyTag: ''


### PR DESCRIPTION
Support passing `stringify` options through to xmlbuilder for more control over how XML is generated.

Fixes #450 