### PR TITLE
Add reference to isomorphic-xml2js

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Simple XML to JavaScript object converter. It supports bi-directional conversion
 Uses [sax-js](https://github.com/isaacs/sax-js/) and
 [xmlbuilder-js](https://github.com/oozcitak/xmlbuilder-js/).
 
+If you are targeting the browser, consider using [isomorphic-xml2js](https://github.com/rikkigibson/isomorphic-xml2js), which implements most of the features of xml2js but at a much smaller bundle size.
+
 Note: If you're looking for a full DOM parser, you probably want
 [JSDom](https://github.com/tmpvar/jsdom).
 


### PR DESCRIPTION
I created an [implementation of about 80-85% of xml2js functionality](https://github.com/rikkigibson/isomorphic-xml2js) which bundles to about 5% of the size of xml2js in the browser, and simply exports xml2js when `require`d in a nodejs environment. I'm hoping this can be of value to people, so please consider adding a reference to the project in your README. Thanks for your consideration!