### PR TITLE
Update dev dependency (closes #457)

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,14 +77,14 @@
   },
   "devDependencies": {
     "coffee-script": ">=1.10.0",
-    "coveralls": "^2.11.2",
+    "coveralls": "^3.0.1",
     "diff": ">=1.0.8",
     "docco": ">=0.6.2",
     "nyc": ">=2.2.1",
     "zap": ">=0.2.9"
   },
-  "engines" : {
-    "node" : ">=4.0.0"
+  "engines": {
+    "node": ">=4.0.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Update coveralls dev dependecy to v3.
v2 is vulnerable according to npm audit.