### PR TITLE
return string version if parsed number is Infinity

### DIFF
--- a/lib/processors.js
+++ b/lib/processors.js
@@ -18,8 +18,13 @@
   };
 
   exports.parseNumbers = function(str) {
+    var originalStr;
     if (!isNaN(str)) {
+      originalStr = str;
       str = str % 1 === 0 ? parseInt(str, 10) : parseFloat(str);
+      if (str === 2e308) {
+        return originalStr;
+      }
     }
     return str;
   };

--- a/src/processors.coffee
+++ b/src/processors.coffee
@@ -14,7 +14,10 @@ exports.stripPrefix = (str) ->
 
 exports.parseNumbers = (str) ->
   if !isNaN str
+    originalStr = str
     str = if str % 1 == 0 then parseInt str, 10 else parseFloat str
+    if str == Infinity
+      return originalStr
   return str
 
 exports.parseBooleans = (str) ->

--- a/test/processors.test.coffee
+++ b/test/processors.test.coffee
@@ -38,6 +38,8 @@ module.exports =
     equ processors.parseNumbers('123'), 123
     equ processors.parseNumbers('15.56'), 15.56
     equ processors.parseNumbers('10.00'), 10
+    equ processors.parseNumbers('476677170e9305605797914192894822'), '476677170e9305605797914192894822'
+    assert.notStrictEqual processors.parseNumbers('476677170e9305605797914192894822'), Infinity
     test.done()
 
   'test parseBooleans': (test) ->
@@ -52,7 +54,7 @@ module.exports =
     equ processors.parseBooleans('x'), 'x'
     equ processors.parseBooleans(''), ''
     test.done()
-    
+
   'test a processor that filters by node name': (test) ->
     xml = '<account><accountNumber>0012345</accountNumber><balance>123.45</balance></account>'
     options = { valueProcessors: [parseNumbersExceptAccount] }
@@ -60,7 +62,7 @@ module.exports =
       equ parsed.account.accountNumber, '0012345'
       equ parsed.account.balance, 123.45
       test.finish()
-      
+
   'test a processor that filters by attr name': (test) ->
     xml = '<account accountNumber="0012345" balance="123.45" />'
     options = { attrValueProcessors: [parseNumbersExceptAccount] }


### PR DESCRIPTION
I have run into an issue where the string version of `476677170e9305605797914192894822` is parsed as `Infinity`, which is expected. I'm proposing to return the string value if it's `Infinity`.

Or perhaps this should be not the default behavior, but an option passed to the constructor?