### PR TITLE
Updated `events.EventEmitter`(deprecated) to `events` in parser

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -333,7 +333,7 @@
 
     return Parser;
 
-  })(events.EventEmitter);
+  })(events);
 
   exports.parseString = function(str, a, b) {
     var cb, options, parser;

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -15,7 +15,7 @@ processItem = (processors, item, key) ->
   item = process(item, key) for process in processors
   return item
 
-class exports.Parser extends events.EventEmitter
+class exports.Parser extends events
   constructor: (opts) ->
     # if this was called without 'new', create an instance with new and return
     return new exports.Parser opts unless @ instanceof exports.Parser


### PR DESCRIPTION
Fixes  #492