### PR TITLE
builder: support building Date object

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -96,6 +96,8 @@
                     element = render(element.ele(key), entry).up();
                   }
                 }
+              } else if (child instanceof Date) {
+                element = element.ele(key, child.toISOString()).up();
               } else if (typeof child === "object") {
                 element = render(element.ele(key), child).up();
               } else {

--- a/src/builder.coffee
+++ b/src/builder.coffee
@@ -80,11 +80,15 @@ class exports.Builder
               else
                 element = render(element.ele(key), entry).up()
 
-          # Case #4 Objects
+          # Case #4 Date objects
+          else if child instanceof Date
+            element = element.ele(key, child.toISOString()).up()
+
+          # Case #5 Objects
           else if typeof child is "object"
             element = render(element.ele(key), child).up()
 
-          # Case #5 String and remaining types
+          # Case #6 String and remaining types
           else
             if typeof child is 'string' && @options.cdata && requiresCDATA child
               element = element.ele(key).raw(wrapCDATA child).up()

--- a/test/builder.test.coffee
+++ b/test/builder.test.coffee
@@ -281,3 +281,17 @@ module.exports =
     actual = builder.buildObject obj
     diffeq expected, actual
     test.finish()
+
+  'test building Date object': (test) ->
+    expected = """
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <xml>
+        <DateTime>2001-10-26T21:32:52.126Z</DateTime>
+      </xml>
+
+    """
+    builder = new xml2js.Builder()
+    obj = { "xml": { "DateTime": new Date("2001-10-26T21:32:52.126Z") } }
+    actual = builder.buildObject obj
+    diffeq expected, actual
+    test.finish()


### PR DESCRIPTION
Xml2Js is made to support outputting Date object as XML's dateTime,
which is an ISO8601 format string. So, Date's toISOString() is used.

P.S.: I'm not sure how to document this, so no documentation is given.