### PR TITLE
Allow function as default value for parsing empty tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,10 @@ value})``. Possible options are:
   * `normalize` (default: `false`): Trim whitespaces inside text nodes.
   * `explicitRoot` (default: `true`): Set this if you want to get the root
     node in the resulting object.
-  * `emptyTag` (default: `''`): what will the value of empty nodes be.
+  * `emptyTag` (default: `''`): what will the value of empty nodes be. In case
+  you want to use an empty object as a default value, it is better to provide a factory
+   function `() => ({})` instead. Without this function a plain object would
+  become a shared reference across all occurrences with unwanted behavior.
   * `explicitArray` (default: `true`): Always put child nodes in an array if
     true; otherwise an array is created only if there is more than one.
   * `ignoreAttrs` (default: `false`): Ignore all XML attributes and only create

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -170,7 +170,7 @@
       })(this);
       this.saxParser.onclosetag = (function(_this) {
         return function() {
-          var cdata, emptyStr, key, node, nodeName, obj, objClone, old, s, xpath;
+          var base, cdata, emptyStr, key, node, nodeName, obj, objClone, old, ref, s, xpath;
           obj = stack.pop();
           nodeName = obj["#name"];
           if (!_this.options.explicitChildren || !_this.options.preserveChildrenOrder) {
@@ -197,7 +197,7 @@
             }
           }
           if (isEmpty(obj)) {
-            obj = _this.options.emptyTag !== '' ? _this.options.emptyTag : emptyStr;
+            obj = (ref = typeof (base = _this.options).emptyTag === "function" ? base.emptyTag() : void 0) != null ? ref : (_this.options.emptyTag !== '' ? _this.options.emptyTag : emptyStr);
           }
           if (_this.options.validator != null) {
             xpath = "/" + ((function() {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -170,7 +170,7 @@
       })(this);
       this.saxParser.onclosetag = (function(_this) {
         return function() {
-          var base, cdata, emptyStr, key, node, nodeName, obj, objClone, old, ref, s, xpath;
+          var cdata, emptyStr, key, node, nodeName, obj, objClone, old, s, xpath;
           obj = stack.pop();
           nodeName = obj["#name"];
           if (!_this.options.explicitChildren || !_this.options.preserveChildrenOrder) {
@@ -197,7 +197,11 @@
             }
           }
           if (isEmpty(obj)) {
-            obj = (ref = typeof (base = _this.options).emptyTag === "function" ? base.emptyTag() : void 0) != null ? ref : (_this.options.emptyTag !== '' ? _this.options.emptyTag : emptyStr);
+            if (typeof _this.options.emptyTag === 'function') {
+              obj = _this.options.emptyTag();
+            } else {
+              obj = _this.options.emptyTag !== '' ? _this.options.emptyTag : emptyStr;
+            }
           }
           if (_this.options.validator != null) {
             xpath = "/" + ((function() {

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -145,7 +145,10 @@ class exports.Parser extends events.EventEmitter
           obj = obj[charkey]
 
       if (isEmpty obj)
-        obj = @options.emptyTag?() ? (if @options.emptyTag != '' then @options.emptyTag else emptyStr)
+        if typeof @options.emptyTag == 'function'
+          obj = @options.emptyTag()
+        else
+          obj = if @options.emptyTag != '' then @options.emptyTag else emptyStr
 
       if @options.validator?
         xpath = "/" + (node["#name"] for node in stack).concat(nodeName).join("/")

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -145,7 +145,7 @@ class exports.Parser extends events.EventEmitter
           obj = obj[charkey]
 
       if (isEmpty obj)
-        obj = if @options.emptyTag != '' then @options.emptyTag else emptyStr
+        obj = @options.emptyTag?() ? (if @options.emptyTag != '' then @options.emptyTag else emptyStr)
 
       if @options.validator?
         xpath = "/" + (node["#name"] for node in stack).concat(nodeName).join("/")

--- a/test/fixtures/sample.xml
+++ b/test/fixtures/sample.xml
@@ -55,4 +55,7 @@
     <tagNameProcessTest/>
     <valueProcessTest>some value</valueProcessTest>
     <textordertest>this is text with <b>markup</b>   <em>like this</em> in the middle</textordertest>
+    <emptytestanother>
+
+    </emptytestanother>
 </sample>

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -72,6 +72,11 @@ module.exports =
     # determine number of items in object
     equ Object.keys(r.sample.tagcasetest[0]).length, 3)
 
+  'test parse with empty objects and functions': skeleton({emptyTag: ()=> new Object()}, (r)->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    bool = r.sample.emptytestanother[0] is r.sample.emptytest[0]
+    equ bool, false)
+
   'test parse with explicitCharkey': skeleton(explicitCharkey: true, (r) ->
     console.log 'Result object: ' + util.inspect r, false, 10
     equ r.sample.chartest[0].$.desc, 'Test for CHARs'

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -72,7 +72,7 @@ module.exports =
     # determine number of items in object
     equ Object.keys(r.sample.tagcasetest[0]).length, 3)
 
-  'test parse with empty objects and functions': skeleton({emptyTag: ()=> new Object()}, (r)->
+  'test parse with empty objects and functions': skeleton({emptyTag: ()=> ({})}, (r)->
     console.log 'Result object: ' + util.inspect r, false, 10
     bool = r.sample.emptytestanother[0] is r.sample.emptytest[0]
     equ bool, false)


### PR DESCRIPTION
We can now specify empty object as default value when parsing xml. This empty object is then shared as a reference across all occurences - when we assign something to it, new value appears in all default empty objects (we don't want that).

By specifying function as default value for empty object, we can provide factory function which creates new empty object for each occurence individually.