### PR TITLE
New Version Release - Super Important

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "json"
   ],
   "homepage": "https://github.com/Leonidas-from-XIV/node-xml2js",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "author": "Marek Kubica <marek@xivilization.net> (https://xivilization.net)",
   "contributors": [
     "maqr <maqr.lollerskates@gmail.com> (https://github.com/maqr)",


### PR DESCRIPTION
When you publish a new version in package.json **0.4.20**, everyone gets the updated repository, otherwise the project appears "abandoned".  This is more so what @ajssd and I were trying to state here: https://github.com/Leonidas-from-XIV/node-xml2js/pull/496

Upon running **npm update** or **yarn upgrade --latest**.  It will only go as far as your last version release, in this case: **0.4.19** _(Aug 22, 2017 - over 2 years ago!)_ All those wonderful commits you've been pushing are not being pulled into local code bases until you update the release version in package.json.

This has nothing to do with dependency version upgrade bumps, it's all about pushing frequent version releases!  Especially after a critical update, such as dropping support for node versions < 8.