### PR TITLE
fixes #541, add namespace to root item in builder

### DIFF
--- a/src/builder.coffee
+++ b/src/builder.coffee
@@ -28,6 +28,9 @@ class exports.Builder
     @options[key] = value for own key, value of opts
 
   buildObject: (rootObj) ->
+    @build(rootObj).end(@options.renderOpts)
+
+  build: (rootObj) ->
     attrkey = @options.attrkey
     charkey = @options.charkey
 
@@ -99,4 +102,4 @@ class exports.Builder
       headless: @options.headless
       allowSurrogateChars: @options.allowSurrogateChars)
 
-    render(rootElement, rootObj).end(@options.renderOpts)
+    render(rootElement, rootObj)


### PR DESCRIPTION
This PR Closes #541 

In xml2js, you can't add attribute to a node if its child nodes form an array. In this case, you can only use "-" to add text nodes.
I reckon it would be better to open the `builder` object since this can largely increase the possibilities to manipulate with xml2js for more particular cases. Also, Parser can access the Parser object through `parser.saxParser`.
And the problem mentioned in #541 can be solved this way:

```javascript
    const urls = [{ url: "node1" }, { url: "node2" }, { url: "node3" }];

    const root = {
        urlset: {
            $: { xmlns: 'http://www.sitemaps.org/schemas/sitemap/0.9' }
        }
    }

    const builder = new xml2js.Builder();
    const rootNode = builder.build(root);

    const xmlString = rootNode.ele(urls).end(xml2js.defaults["0.2"].renderOpts);

    console.log(xmlString);
```
output:
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <url>node1</url>
  <url>node2</url>
  <url>node3</url>
</urlset>
```
