### PR TITLE
Update xmlbuilder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xml2js",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1704,9 +1704,9 @@
       }
     },
     "xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.0.0.tgz",
+      "integrity": "sha512-KLu/G0DoWhkncQ9eHSI6s0/w+T4TM7rQaLhtCaL6tORv8jFlJPlnGumsgTcGfYeS1qZ/IHqrvDG7zJZ4d7e+nw=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "sax": ">=0.6.0",
-    "xmlbuilder": "~11.0.0"
+    "xmlbuilder": "~15.0.0"
   },
   "devDependencies": {
     "coffee-script": ">=1.10.0",
@@ -86,7 +86,7 @@
     "zap": ">=0.2.9"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
* Update xmlbuilder to version 15. 
* Bump minimum node version to v8 since that is what the latest version of `xmlbuilder` supports.
* Potentially fixes https://github.com/Leonidas-from-XIV/node-xml2js/issues/555