### PR TITLE
Fix includeWhiteChars option

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -182,7 +182,7 @@
             delete obj.cdata;
           }
           s = stack[stack.length - 1];
-          if (obj[charkey].match(/^\s*$/) && !cdata) {
+          if (obj[charkey].match(/^\s*$/) && !cdata && !_this.options.includeWhiteChars) {
             emptyStr = obj[charkey];
             delete obj[charkey];
           } else {

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -132,7 +132,7 @@ class exports.Parser extends events
 
       s = stack[stack.length - 1]
       # remove the '#' key altogether if it's blank
-      if obj[charkey].match(/^\s*$/) and not cdata
+      if obj[charkey].match(/^\s*$/) and not cdata and not @options.includeWhiteChars
         emptyStr = obj[charkey]
         delete obj[charkey]
       else


### PR DESCRIPTION
Currently, we do not receive any whitespace-characters, even if `includeWhiteChars` is set to true.
This is also a fix for https://github.com/Leonidas-from-XIV/node-xml2js/issues/582.

One more sidenote:
If there is an overload of pull requests, please let me know whether this library is still maintained, or whether you are looking for a new maintainer.
