### PR TITLE
Tiny english correction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ If you want to parse multiple files, you have multiple possibilities:
   * You can hope everything goes well anyway. This behaviour is not
     guaranteed work always, if ever. Use option #1 if possible. Thanks!
 
-So you wanna some JSON?
+Wanna get some JSON?
 -----------------------
 
 Just wrap the `result` object in a call to `JSON.stringify` like this


### PR DESCRIPTION
I was just browsing through the README and I found this little mistake.
'Wanna' needs to be followed by a verb.

`So you wanna some JSON?` => `So you want to (?) some JSON?` => ❌
`Wanna get some JSON?` => `Want to get some JSON?` => ✔