### PR TITLE
Enable setting attributes when building obj with array

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -60,9 +60,18 @@
             for (index in obj) {
               if (!hasProp.call(obj, index)) continue;
               child = obj[index];
-              for (key in child) {
-                entry = child[key];
-                element = render(element.ele(key), entry).up();
+              if (index === attrkey) {
+                if (typeof child === "object") {
+                  for (attr in child) {
+                    value = child[attr];
+                    element = element.att(attr, value);
+                  }
+                }
+              } else {
+                for (key in child) {
+                  entry = child[key];
+                  element = render(element.ele(key), entry).up();
+                }
               }
             }
           } else {

--- a/src/builder.coffee
+++ b/src/builder.coffee
@@ -51,8 +51,14 @@ class exports.Builder
       else if Array.isArray obj
         # fix issue #119
         for own index, child of obj
-          for key, entry of child
-            element = render(element.ele(key), entry).up()
+          # allow setting attributes for parents with multiple childrens
+          if index is attrkey
+            if typeof child is "object"
+              for attr, value of child
+                element = element.att(attr, value)
+          else
+            for key, entry of child
+              element = render(element.ele(key), entry).up()
       else
         for own key, child of obj
           # Case #1 Attribute

--- a/test/builder.test.coffee
+++ b/test/builder.test.coffee
@@ -281,3 +281,20 @@ module.exports =
     actual = builder.buildObject obj
     diffeq expected, actual
     test.finish()
+
+  'test building obj with array and attributes': (test) ->
+    expected = """
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <root name="myName">
+        <MsgId>10</MsgId>
+        <MsgId2>12</MsgId2>
+      </root>
+
+    """
+    opts = cdata: true
+    builder = new xml2js.Builder opts
+    obj = [{"MsgId": 10}, {"MsgId2": 12}]
+    obj.$ = {"name": "myName"}
+    actual = builder.buildObject obj
+    diffeq expected, actual
+    test.finish()


### PR DESCRIPTION
This solves #624

This allows setting attributes on parent elements, while preserving the order of its children, when using `builder.buildObject()`.

I know this is some rather hakish code, as we are setting properties on an array, but I don't see any other way of providing this functionality. Please let me know, if we should follow a different approach here.

Example:

```javascript
let children = [{Literal: 'foo'}, {PropertyName: 'bar'}, {Literal: 'baz'}];
children.$ = {name: 'faz'};
builder.buildObject({Parent: [children]});
```

leads to following result:

```xml
<Parent name="faz">
  <Literal>foo<Literal>
  <PropertyName>bar</PropertyName>
  <Literal>baz<Literal>
</Parent>
```