### PR TITLE
Add custom node post-processing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,23 @@ value})``. Possible options are:
       return name
     }
     ```
-    Added in 0.4.6
+
+    Added in 0.x.y
+  * `nodeProcessors` (default: `null`): Allows custom processing to be run on a node after xml2js has converted it. Accepts an `Array` of objects with two functions:
+    ```javascript
+    // Processor to convert the XML node "<Foo type="integer">1234</Foo>" to the number "1234"
+    {
+      canProcess: function(node) {
+        // If node has "integer" attribute, this processor will handle it
+        return node?.$?.type === "integer";
+      },
+      process: function(node) {
+        // Replace this node with the parsed text contents
+        return Number.parseInt(node._);
+      }
+    }
+    ```
+    `nodeProcessors` are applied in the order they appear in.
 
 Options for the `Builder` class
 -------------------------------

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -24,6 +24,7 @@
       attrValueProcessors: null,
       tagNameProcessors: null,
       valueProcessors: null,
+      nodeProcessors: null,
       emptyTag: ''
     },
     "0.2": {
@@ -50,6 +51,7 @@
       attrValueProcessors: null,
       tagNameProcessors: null,
       valueProcessors: null,
+      nodeProcessors: null,
       rootName: 'root',
       xmldec: {
         'version': '1.0',

--- a/src/defaults.coffee
+++ b/src/defaults.coffee
@@ -33,6 +33,7 @@ exports.defaults = {
     attrValueProcessors: null
     tagNameProcessors: null
     valueProcessors: null
+    nodeProcessors: null
     emptyTag: ''
 
   "0.2":
@@ -61,6 +62,7 @@ exports.defaults = {
     attrValueProcessors: null
     tagNameProcessors: null
     valueProcessors: null
+    nodeProcessors: null
     # xml building options
     rootName: 'root'
     xmldec: {'version': '1.0', 'encoding': 'UTF-8', 'standalone': true}

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -190,6 +190,11 @@ class exports.Parser extends events
           if Object.keys(obj).length == 1 and charkey of obj and not @EXPLICIT_CHARKEY
             obj = obj[charkey]
 
+      if @options.nodeProcessors?
+        for processor in @options.nodeProcessors
+          if processor.canProcess obj
+            obj = processor.process obj
+
       # check whether we closed all the open tags
       if stack.length > 0
         @assignOrPush s, nodeName, obj

--- a/test/fixtures/sample.xml
+++ b/test/fixtures/sample.xml
@@ -58,4 +58,5 @@
     <emptytestanother>
 
     </emptytestanother>
+    <nodeProcessorTest type="number">1234</nodeProcessorTest>
 </sample>

--- a/test/parser.test.coffee
+++ b/test/parser.test.coffee
@@ -40,6 +40,11 @@ nameCutoff = (name) ->
 replaceValueByName = (value, name) ->
   return name
 
+sampleNodeProcessor =
+  canProcess: (node) -> node?.$?.type == "number"
+  process: (node) -> Number.parseInt(node._)
+
+
 ###
 The `validator` function validates the value at the XPath. It also transforms the value
 if necessary to conform to the schema or other validation information being used. If there
@@ -599,7 +604,11 @@ module.exports =
   'test valueProcessors key param': skeleton(valueProcessors: [replaceValueByName], (r)->
     console.log 'Result object: ' + util.inspect r, false, 10
     equ r.sample.valueProcessTest[0], 'valueProcessTest')
-  
+
+  'test nodeProcessors': skeleton(nodeProcessors: [sampleNodeProcessor], (r)->
+    console.log 'Result object: ' + util.inspect r, false, 10
+    equ r.sample.nodeProcessorTest[0], 1234)
+
   'test parseStringPromise parsing': (test) ->
     x2js = new xml2js.Parser()
     readFilePromise(fileName).then (data) ->
@@ -610,7 +619,7 @@ module.exports =
       test.finish()
     .catch (err) ->
       test.fail('Should not error')
-    
+
   'test parseStringPromise with bad input': (test) ->
     x2js = new xml2js.Parser()
     x2js.parseStringPromise("< a moose bit my sister>").then (r) ->
@@ -640,7 +649,7 @@ module.exports =
       test.finish()
     .catch (err) ->
       test.fail('Should not error')
-    
+
   'test global parseStringPromise with bad input': (test) ->
     xml2js.parseStringPromise("< a moose bit my sister>").then (r) ->
       test.fail('Should fail')


### PR DESCRIPTION
I was able to get some processing functionality working by writing a validator that manipulated the data but that seemed wrong, unintuitive, and currently you can only have one validator function per parser config.

I appreciate that the two-function way I've written might not be best. If you prefer I can change it to be a simple array of functions. For an example of this, here's the sample processor I put in the readme:

``` javascript
{
  canProcess: function(node) {
    return node?.$?.type === "integer";
  },
  process: function(node) {
    return Number.parseInt(node._);
  }
}
```

And here's the alternative approach:
```  javascript
function(node) {
  if (node?.$?.type === "integer")
    return Number.parseInt(node._);
  return node;
}
```

Let me know if this is preferable, or if there are any other changes you'd like to see on this.