### PR TITLE
Improved fix for CVE-2023-0842

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -52,6 +52,8 @@ class exports.Parser extends events
         @emit err
 
   assignOrPush: (obj, key, newValue) =>
+    return if key == '__proto__'
+    return if key == 'constructor'
     if key not of obj
       if not @options.explicitArray
         obj[key] = newValue
@@ -113,7 +115,7 @@ class exports.Parser extends events
           if @options.mergeAttrs
             @assignOrPush obj, processedKey, newValue
           else
-            obj[attrkey][processedKey] = newValue
+            @assignOrPush obj[attrkey], processedKey, newValue
 
       # need a place to store the node name
       obj["#name"] = if @options.tagNameProcessors then processItem(@options.tagNameProcessors, node.name) else node.name

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -102,12 +102,12 @@ class exports.Parser extends events
     charkey = @options.charkey
 
     @saxParser.onopentag = (node) =>
-      obj = Object.create(null)
+      obj = {}
       obj[charkey] = ""
       unless @options.ignoreAttrs
         for own key of node.attributes
           if attrkey not of obj and not @options.mergeAttrs
-            obj[attrkey] = Object.create(null)
+            obj[attrkey] = {}
           newValue = if @options.attrValueProcessors then processItem(@options.attrValueProcessors, node.attributes[key], key) else node.attributes[key]
           processedKey = if @options.attrNameProcessors then processItem(@options.attrNameProcessors, key) else key
           if @options.mergeAttrs
@@ -163,7 +163,7 @@ class exports.Parser extends events
       # put children into <childkey> property and unfold chars if necessary
       if @options.explicitChildren and not @options.mergeAttrs and typeof obj is 'object'
         if not @options.preserveChildrenOrder
-          node = Object.create(null)
+          node = {}
           # separate attributes
           if @options.attrkey of obj
             node[@options.attrkey] = obj[@options.attrkey]
@@ -181,7 +181,7 @@ class exports.Parser extends events
           # append current node onto parent's <childKey> array
           s[@options.childkey] = s[@options.childkey] or []
           # push a clone so that the node in the children array can receive the #name property while the original obj can do without it
-          objClone = Object.create(null)
+          objClone = {}
           for own key of obj
             objClone[key] = obj[key]
           s[@options.childkey].push objClone
@@ -198,7 +198,7 @@ class exports.Parser extends events
         if @options.explicitRoot
           # avoid circular references
           old = obj
-          obj = Object.create(null)
+          obj = {}
           obj[nodeName] = old
 
         @resultObject = obj


### PR DESCRIPTION
This is potentially a better fix for [CVE-2023-0842](https://nvd.nist.gov/vuln/detail/CVE-2023-0842) that does not have the regressions mentioned in issue #672 

The idea here is that the CVE (slightly more details [here](https://avd.aquasec.com/nvd/2023/cve-2023-0842/) ) is specifically referring to the modification of the base object prototype through the merging of objects.

I think that this is the type of modification it is referring to:
```js
// simulated exploit
({}).__proto__.foo = 1;
({})['constructor'].prototype.bar = 2;
// now any javascript object will contain these properties and values!
console.log({}.foo); // outputs 1
console.log({}.bar); // outputs 2
```

So, the solution in this PR is to explicitly block the properties `__proto__` and `constructor`.
I don't think it is necessary to block `prototype` because that is only destructive through access via `constructor`.

I tried to cover all locations in the code that seemed to be merging objects, but I may have missed a location or two in this codebase which is quite unfamiliar to me, and written in a language I don't know.

PS. I was not able to verify if this fix covers all possibilities through tests because it doesn't seem like there are any explicit tests for the CVE. CoffeeScript is very foreign to me, so I wouldn't even know where to look for these!