### PR TITLE
Add a GitHub action to build the package and run the tests against Node 16, 18 and 20

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,17 @@
+name: xml2js tests
+on: [ push ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 'current', 'lts/*', 'lts/-1' ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build
+      - run: npm run coverage

--- a/Cakefile
+++ b/Cakefile
@@ -1,8 +1,8 @@
 {spawn, exec} = require 'child_process'
 
-task 'build', 'continually build the JavaScript code', ->
+task 'build', 'build the JavaScript code', ->
   coffeeScript = if process.platform == 'win32' then 'coffee.cmd' else 'coffee'
-  coffee = spawn coffeeScript, ['-cw', '-o', 'lib', 'src']
+  coffee = spawn coffeeScript, ['-c', '-o', 'lib', 'src']
   coffee.stdout.on 'data', (data) -> console.log data.toString().trim()
 
 task 'doc', 'rebuild the Docco documentation', ->


### PR DESCRIPTION
Thank you @Leonidas-from-XIV for you work.

This adds a GitHub actions pipeline to build the library and run the tests against Node 16, 18 and 20 (the previous LTS, the current LTS and the current release).

It uses the existing scripts for the build and test:
- build: `npm run build`,
- test: `npm run coverage`

A limitation of this change is that running the tests through the existing script `npm run coverage` succeeds without reporting the run of any test.