### PR TITLE
chore: add publish workflow (OIDC npm)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,13 @@
+name: publish
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  tests:
+    uses: brickhouse-tech/.github/.github/workflows/tests.yml@main
+    with:
+      node-versions: '["18.x", "20.x", "22.x"]'
+  publish:
+    needs: [tests]
+    uses: brickhouse-tech/.github/.github/workflows/publish.yml@main


### PR DESCRIPTION
Adds publish workflow using shared brickhouse-tech/.github reusable workflow. CI tests and release already wired up.