### PR TITLE
Fix `npm test` running 0 tests, add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18.x, 20.x, 22.x, 24.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "xmlbuilder": "~11.0.0"
       },
       "devDependencies": {
-        "coffeescript": ">=1.10.0 <2",
+        "coffee-script": "npm:coffeescript@>=1.10.0 <2",
         "coveralls": "^3.0.1",
         "diff": ">=1.0.8",
         "docco": ">=0.6.2",
@@ -320,11 +320,13 @@
         "wrap-ansi": "^5.1.0"
       }
     },
-    "node_modules/coffeescript": {
+    "node_modules/coffee-script": {
+      "name": "coffeescript",
       "version": "1.12.7",
       "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
       "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "cake": "bin/cake",
         "coffee": "bin/coffee"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "xmlbuilder": "~11.0.0"
   },
   "devDependencies": {
-    "coffeescript": ">=1.10.0 <2",
+    "coffee-script": "npm:coffeescript@>=1.10.0 <2",
     "coveralls": "^3.0.1",
     "diff": ">=1.0.8",
     "docco": ">=0.6.2",


### PR DESCRIPTION
On a fresh checkout, `npm test` currently prints "All of 0 tests passed. Yeah!" — the suite does not run at all.

Root cause: zap only picks up `.test.coffee` files when `require('coffee-script/register')` succeeds. b856cb8 switched the devDependency to the renamed `coffeescript` package, so a fresh `npm install` leaves zap without a compiler and it silently falls back to `*.test.js` (of which there are none).

The fix is a one-liner: install `coffeescript` under its legacy name with an npm alias (`"coffee-script": "npm:coffeescript@>=1.10.0 <2"`). Same package, same version range, and the `coffee`/`cake` binaries are unaffected. With this, all 99 tests run and pass.

Since this shipped in two releases without anyone noticing, I also added a minimal GitHub Actions workflow (Node 18/20/22/24, `npm ci && npm test`) so a regression like this cannot stay silent again.

Overlaps partially with #686, which gets CI working by precompiling the tests to JS via extra cake tasks; this PR instead fixes `npm test` itself, so the workflow stays a plain `npm ci && npm test`.