### PR TITLE
fix: escape all CDATA end sequences in builder

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -17,7 +17,7 @@
   };
 
   escapeCDATA = function(entry) {
-    return entry.replace(']]>', ']]]]><![CDATA[>');
+    return entry.replace(/]]>/g, ']]]]><![CDATA[>');
   };
 
   exports.Builder = (function() {

--- a/src/builder.coffee
+++ b/src/builder.coffee
@@ -17,7 +17,7 @@ escapeCDATA = (entry) ->
   # The first contains the ']]'
   # The second contains the '>'
   # When later parsed, it will be put back together as ']]>'
-  return entry.replace ']]>', ']]]]><![CDATA[>'
+  return entry.replace /]]>/g, ']]]]><![CDATA[>'
 
 class exports.Builder
   constructor: (opts) ->

--- a/test/builder.test.coffee
+++ b/test/builder.test.coffee
@@ -204,6 +204,19 @@ module.exports =
     diffeq expected, actual
     test.finish()
 
+  'test cdata text nodes with multiple escaped end sequences round-trip': (test) ->
+    # A value with two `]]>` sequences must round-trip exactly; every
+    # occurrence has to be split or the second one prematurely closes the
+    # CDATA section (XML 1.0 section 2.7) and corrupts the data.
+    value = "a ]]> b ]]> c"
+    opts = cdata: true
+    builder = new xml2js.Builder opts
+    xml = builder.buildObject {"xml":{"MsgId":[value]}}
+    xml2js.parseString xml, (err, parsed) ->
+      throw err if err
+      equ parsed.xml.MsgId[0], value
+      test.finish()
+
   'test uses cdata only for chars &, <, >': (test) ->
     expected = """
       <?xml version="1.0" encoding="UTF-8" standalone="yes"?>


### PR DESCRIPTION
## Problem

When `cdata: true` is set on the `Builder`, a string value that contains **two or more** `]]>` sequences produces invalid XML and is corrupted on round-trip.

```js
const xml2js = require('xml2js')

const value = 'a ]]> b ]]> c'
const xml = new xml2js.Builder({ cdata: true }).buildObject({ r: value })
// emits: <r><![CDATA[a ]]]]><![CDATA[> b ]]> c]]></r>
//                                          ^^^ second ]]> left intact

xml2js.parseString(xml, (err, res) => {
  console.log(res.r) // 'a ]]> b  c]]>'  (corrupted; expected 'a ]]> b ]]> c')
})
```

The first `]]>` is split correctly, but the second one survives intact. Per XML 1.0 [section 2.7](https://www.w3.org/TR/xml/#sec-cdata-sect), a CDATA section ends at the first literal `]]>`, so that second sequence prematurely terminates the section. The remaining text is then re-parsed as element content, dropping/garbling characters and (depending on the value) emitting malformed XML. A value with a single `]]>` round-trips fine, which is why this slipped through.

## Root cause

`escapeCDATA` uses a non-global string `replace`, which only replaces the first occurrence:

```js
escapeCDATA = function(entry) {
  return entry.replace(']]>', ']]]]><![CDATA[>');
};
```

## Fix

Use a global regex so every `]]>` occurrence is split:

```js
return entry.replace(/]]>/g, ']]]]><![CDATA[>');
```

Applied to both the CoffeeScript source (`src/builder.coffee`) and the committed compiled output (`lib/builder.js`); the compiled change matches `coffee -c` output exactly.

## Tests

Added a round-trip test asserting that a value with two `]]>` sequences survives `Builder({ cdata: true })` -> `parseString` unchanged.

- Before the fix: the new test fails with `'a ]]> b  c]]>' == 'a ]]> b ]]> c'`.
- After the fix: full suite green (100 tests pass, exit 0).